### PR TITLE
Feature/maple sim: gamepieces

### DIFF
--- a/src/main/java/competition/simulation/MapleSimulator.java
+++ b/src/main/java/competition/simulation/MapleSimulator.java
@@ -3,6 +3,7 @@ package competition.simulation;
 import competition.subsystems.drive.DriveSubsystem;
 import competition.subsystems.pose.PoseSubsystem;
 import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.kinematics.SwerveModuleState;
@@ -38,6 +39,7 @@ public class MapleSimulator implements BaseSimulator {
         aKitLog = new AKitLogger("Simulator/");
 
         arena = SimulatedArena.getInstance();
+        arena.resetFieldForAuto();
         // TODO: custom things to provide here like motor ratios and what have you
         config = DriveTrainSimulationConfig.Default().withCustomModuleTranslations(new Translation2d[] {
                 drive.getFrontLeftSwerveModuleSubsystem().getModuleTranslation(),
@@ -72,6 +74,11 @@ public class MapleSimulator implements BaseSimulator {
         swerveDriveSimulation.periodic();
 
         // read values back out from sim
+        aKitLog.record(
+                "FieldSimulation/Algae", arena.getGamePiecesArrayByType("Algae"));
+        aKitLog.record(
+                "FieldSimulation/Coral", arena.getGamePiecesArrayByType("Coral"));
+
         aKitLog.record("RobotGroundTruthPose", swerveDriveSimulation.getActualPoseInSimulationWorld());
         aKitLog.record("MapleOdometryPose", swerveDriveSimulation.getOdometryEstimatedPose());
 
@@ -86,6 +93,7 @@ public class MapleSimulator implements BaseSimulator {
 
     @Override
     public void resetPosition(Pose2d pose) {
+        arena.resetFieldForAuto();
         this.swerveDriveSimulation.getDriveTrainSimulation().setSimulationWorldPose(pose);
         this.pose.setCurrentPoseInMeters(pose);
     }


### PR DESCRIPTION
# Why are we doing this?

Render the game pieces that maple-sim keeps track of. Right now it's just the starting pieces but it's a start.

Asana task URL:

# Whats changing?

# Questions/notes for reviewers

# How this was tested
![image](https://github.com/user-attachments/assets/3193dee1-94a2-470d-acde-dc52e973f231)


- [ ] unit tests added
- [ ] tested on robot

-----

PR feedback legend

 
| Symbol | Meaning                  |
|--------|--------------------------|
| :star: :star: :star:     | must be addressed                 |
| :star: :star:     | should be addressed        |
| :star:     | something to consider, a good idea                  |
