### PR TITLE
AdvantageScope: xbot 2025 model

### DIFF
--- a/AdvantageScope/custom_assets/Robot_Xbot2025/config.json
+++ b/AdvantageScope/custom_assets/Robot_Xbot2025/config.json
@@ -1,0 +1,53 @@
+{
+  "name": "Xbot 2025",
+  "sourceUrl": "https://firstfrc.blob.core.windows.net/frc2024/KitBot/KitBot%20CAD%20and%20Drawings.zip",
+  "rotations": [
+    {
+      "axis": "x",
+      "degrees": 90
+    },
+    {
+      "axis": "z",
+      "degrees": 90
+    }
+  ],
+  "position": [
+    0.3555,0,0
+  ],
+  "cameras": [
+    {
+      "name": "Front Camera",
+      "rotations": [],
+      "position": [
+        0.4,
+        0.4,
+        0.5
+      ],
+      "resolution": [
+        960,
+        720
+      ],
+      "fov": 90
+    },
+    {
+      "name": "Back Camera",
+      "rotations": [
+        {
+          "axis": "z",
+          "degrees": 180
+        }
+      ],
+      "position": [
+        -0.35,
+        0,
+        0.5
+      ],
+      "resolution": [
+        960,
+        720
+      ],
+      "fov": 90
+    }
+  ],
+  "components": []
+}


### PR DESCRIPTION
# Why are we doing this?

To help visualize our robot (vs the kitbot)

Asana task URL:

# Whats changing?

Adds custom assets folder in repo that has 2025 robot in it

# Questions/notes for reviewers

This is the current assembly as 1 big model, and it's missing bumpers.

Longer term would be nice to have the elevator separate so we could show it moving up and down (and maybe the arm rotating too).

I'm also not sure what the 'front' is, might need to do some rotating

# How this was tested
![image](https://github.com/user-attachments/assets/8d845a36-83e7-48e1-8d27-7244758d9b21)


- [ ] unit tests added
- [ ] tested on robot

-----

PR feedback legend

 
| Symbol | Meaning                  |
|--------|--------------------------|
| :star: :star: :star:     | must be addressed                 |
| :star: :star:     | should be addressed        |
| :star:     | something to consider, a good idea                  |
