### PR TITLE
ElevatorMechanism: have arm show state from ArmSim

### DIFF
--- a/src/main/java/competition/simulation/arm/ArmSimConstants.java
+++ b/src/main/java/competition/simulation/arm/ArmSimConstants.java
@@ -14,7 +14,7 @@ public class ArmSimConstants {
     public static final Mass armMass = Kilogram.of(8.0); // Kilograms
     public static final Distance armLength = Meters.of(0.5);
     public static final Angle minAngleRads = Degrees.of(-45);
-    public static final Angle maxAngleRads = Degrees.of(90);
+    public static final Angle maxAngleRads = Degrees.of(125 - 45);
     public static final Angle startingAngle = minAngleRads;
     public static final Angle armEncoderAnglePerRotation = Degrees.of(0.1);
 }

--- a/src/main/java/competition/simulation/arm/ArmSimulator.java
+++ b/src/main/java/competition/simulation/arm/ArmSimulator.java
@@ -48,9 +48,12 @@ public class ArmSimulator {
         armSim.update(SimulationConstants.loopPeriodSec); // 20ms
 
         // Read out the new arm position for rendering
+        // TODO: the frame of reference of the simulated arm is wrong, gravity isn't being applied
+        // in the same way we think
         var armMotorRotations = armSim.getAngleRads() / ArmSimConstants.armEncoderAnglePerRotation.in(Radians);
 
         armMotor.setPosition(Rotations.of(armMotorRotations));
-        elevatorMechanism.armAngle = Radians.of(armSim.getAngleRads());
+        // correct for frame of reference for the arm pivot in the mechanism vs sim model
+        elevatorMechanism.armAngle = Radians.of(armSim.getAngleRads()).plus(ArmSimConstants.minAngleRads.times(-1)).times(-1);
     }
 }


### PR DESCRIPTION
# Why are we doing this?

Allow students to program the arm and see it move

Asana task URL:

# Whats changing?

# Questions/notes for reviewers

There's a big problem where the frame of reference doesn't line up, gravity isn't being applied correctly.

# How this was tested
- [ ] unit tests added
- [ ] tested on robot

In simulator:

https://github.com/user-attachments/assets/480c9d60-f372-4101-b36f-ddf6149dec87


-----

PR feedback legend

 
| Symbol | Meaning                  |
|--------|--------------------------|
| :star: :star: :star:     | must be addressed                 |
| :star: :star:     | should be addressed        |
| :star:     | something to consider, a good idea                  |
