### PR TITLE
Subsystem refreshables

### DIFF
--- a/src/main/java/competition/subsystems/algae_collection/AlgaeCollectionSubsystem.java
+++ b/src/main/java/competition/subsystems/algae_collection/AlgaeCollectionSubsystem.java
@@ -24,6 +24,7 @@ public class AlgaeCollectionSubsystem extends BaseSubsystem {
         if (electricalContract.isAlgaeCollectionReady()) {
             this.motor = xcanMotorControllerFactory.create(electricalContract.getAlgaeCollectionMotor(),
                     getPrefix(), "AlgaeMotor");
+            this.registerDataFrameRefreshable(motor);
         } else {
             this.motor = null;
         }

--- a/src/main/java/competition/subsystems/arm_pivot/ArmPivotSubsystem.java
+++ b/src/main/java/competition/subsystems/arm_pivot/ArmPivotSubsystem.java
@@ -15,7 +15,7 @@ import static edu.wpi.first.units.Units.Degrees;
 import static edu.wpi.first.units.Units.Rotations;
 
 @Singleton
-public class ArmPivotSubsystem extends BaseSetpointSubsystem<Angle> implements DataFrameRefreshable {
+public class ArmPivotSubsystem extends BaseSetpointSubsystem<Angle> {
     public final XCANMotorController armMotor;
     Angle targetAngle;
     ElectricalContract electricalContract;
@@ -32,6 +32,7 @@ public class ArmPivotSubsystem extends BaseSetpointSubsystem<Angle> implements D
         if (electricalContract.isArmPivotMotorReady()) {
             this.armMotor = xcanMotorControllerFactory.create(electricalContract.getArmPivotMotor(),
                     getPrefix(), "ArmPivotMotor");
+            this.registerDataFrameRefreshable(this.armMotor);
         } else {
             this.armMotor = null;
         }
@@ -72,12 +73,5 @@ public class ArmPivotSubsystem extends BaseSetpointSubsystem<Angle> implements D
     @Override
     protected boolean areTwoTargetsEquivalent(Angle target1, Angle target2) {
         return target1.isEquivalent(target2);
-    }
-
-    @Override
-    public void refreshDataFrame() {
-        if(electricalContract.isArmPivotMotorReady()) {
-            this.armMotor.refreshDataFrame();
-        }
     }
 }

--- a/src/main/java/competition/subsystems/coral_scorer/CoralScorerSubsystem.java
+++ b/src/main/java/competition/subsystems/coral_scorer/CoralScorerSubsystem.java
@@ -1,11 +1,9 @@
 package competition.subsystems.coral_scorer;
 
 import competition.electrical_contract.ElectricalContract;
-import xbot.common.advantage.DataFrameRefreshable;
 import xbot.common.command.BaseSubsystem;
 import xbot.common.controls.actuators.XCANMotorController;
 import xbot.common.controls.sensors.XDigitalInput;
-import xbot.common.properties.BooleanProperty;
 import xbot.common.properties.DoubleProperty;
 import xbot.common.properties.PropertyFactory;
 

--- a/src/main/java/competition/subsystems/coral_scorer/CoralScorerSubsystem.java
+++ b/src/main/java/competition/subsystems/coral_scorer/CoralScorerSubsystem.java
@@ -13,7 +13,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 @Singleton
-public class CoralScorerSubsystem extends BaseSubsystem implements DataFrameRefreshable {
+public class CoralScorerSubsystem extends BaseSubsystem {
     public final XCANMotorController motor;
     public final DoubleProperty intakePower;
     public final DoubleProperty scorePower;
@@ -28,6 +28,7 @@ public class CoralScorerSubsystem extends BaseSubsystem implements DataFrameRefr
         if (electricalContract.isCoralCollectionMotorReady()) {
             this.motor = xcanMotorControllerFactory.create(electricalContract.getCoralCollectionMotor(),
                     getPrefix(), "CoralScorer");
+            this.registerDataFrameRefreshable(motor);
         } else {
             this.motor = null;
         }
@@ -35,6 +36,7 @@ public class CoralScorerSubsystem extends BaseSubsystem implements DataFrameRefr
         if (electricalContract.isCoralSensorReady()) {
             this.coralSensor = xDigitalInputFactory.create(electricalContract.getCoralSensor(),
                     "CoralSensor");
+            this.registerDataFrameRefreshable(coralSensor);
         } else {
             this.coralSensor = null;
         }
@@ -69,10 +71,6 @@ public class CoralScorerSubsystem extends BaseSubsystem implements DataFrameRefr
 
     public void periodic() {
         aKitLog.record("coralPresent", this.hasCoral());
-    }
-    @Override
-    public void refreshDataFrame() {
-        coralSensor.refreshDataFrame();
     }
 }
 

--- a/src/main/java/competition/subsystems/drive/DriveSubsystem.java
+++ b/src/main/java/competition/subsystems/drive/DriveSubsystem.java
@@ -26,7 +26,7 @@ import xbot.common.subsystems.drive.BaseSwerveDriveSubsystem;
 import java.util.function.Supplier;
 
 @Singleton
-public class DriveSubsystem extends BaseSwerveDriveSubsystem implements DataFrameRefreshable {
+public class DriveSubsystem extends BaseSwerveDriveSubsystem {
     private static Logger log = LogManager.getLogger(DriveSubsystem.class);
 
     private Translation2d lookAtPointTarget = new Translation2d(); // The target point to look at

--- a/src/main/java/competition/subsystems/elevator/ElevatorSubsystem.java
+++ b/src/main/java/competition/subsystems/elevator/ElevatorSubsystem.java
@@ -14,7 +14,7 @@ import static edu.wpi.first.units.Units.Feet;
 import static edu.wpi.first.units.Units.Inches;
 
 @Singleton
-public class ElevatorSubsystem extends BaseSetpointSubsystem<Distance> implements DataFrameRefreshable {
+public class ElevatorSubsystem extends BaseSetpointSubsystem<Distance> {
 
     public enum ElevatorGoals{
         ScoreL1,
@@ -65,6 +65,7 @@ public class ElevatorSubsystem extends BaseSetpointSubsystem<Distance> implement
 
         if(contract.isElevatorReady()){
             this.masterMotor = motorFactory.create(contract.getElevatorMotor(), this.getPrefix(), "ElevatorMotor");
+            this.registerDataFrameRefreshable(masterMotor);
         }
     }
 
@@ -111,13 +112,6 @@ public class ElevatorSubsystem extends BaseSetpointSubsystem<Distance> implement
     @Override
     protected boolean areTwoTargetsEquivalent(Distance target1, Distance target2) {
         return target1.isEquivalent(target2);
-    }
-
-    @Override
-    public void refreshDataFrame() {
-        if(contract.isElevatorReady()){
-            masterMotor.refreshDataFrame();
-        }
     }
 
     public void periodic(){


### PR DESCRIPTION
# Why are we doing this?

Asana task URL:

# Whats changing?

Implement the new way that subsystems can register their dataframe refreshables. Adds it to a few subsystems that were missing it before too.

# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested on robot

-----

PR feedback legend

 
| Symbol | Meaning                  |
|--------|--------------------------|
| :star: :star: :star:     | must be addressed                 |
| :star: :star:     | should be addressed        |
| :star:     | something to consider, a good idea                  |
