### PR TITLE
Trapezoid motion control for elevator

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,8 +7,11 @@ Asana task URL:
 # Questions/notes for reviewers
 
 # How this was tested
-- [ ] unit tests added
 - [ ] tested on robot
+- [ ] tested in simulator
+- [ ] unit tests added
+
+## Video/screenshots (from simulator or live robot)
 
 -----
 

--- a/src/main/java/competition/motion/TrapezoidProfileManager.java
+++ b/src/main/java/competition/motion/TrapezoidProfileManager.java
@@ -31,7 +31,7 @@ public class TrapezoidProfileManager {
         goalState = new TrapezoidProfile.State(initialPosition, 0);
     }
 
-    public void setTargetValue(double targetValue, double currentValue, double currentVelocity) {
+    public void setTargetPosition(double targetValue, double currentValue, double currentVelocity) {
         // if the profile's constraints properties have changed, recompute the profile
         // there's maybe a better place to do this but this should be fine since setTarget will be called
         // over and over again
@@ -50,7 +50,7 @@ public class TrapezoidProfileManager {
     }
 
     // currently only doing position, but in theory this goal has a velocity associated with it too we could use
-    public double getCurrentPositionSetpoint() {
+    public double getRecommendedPositionForTime() {
         var setpoint = profile.calculate(XTimer.getFPGATimestampTime().minus(profileStartTime).in(Seconds), initialState, goalState);
         return setpoint.position;
     }

--- a/src/main/java/competition/motion/TrapezoidProfileManager.java
+++ b/src/main/java/competition/motion/TrapezoidProfileManager.java
@@ -1,0 +1,58 @@
+package competition.motion;
+
+import static edu.wpi.first.units.Units.Seconds;
+
+import edu.wpi.first.math.trajectory.TrapezoidProfile;
+import edu.wpi.first.units.measure.Time;
+import xbot.common.controls.sensors.XTimer;
+import xbot.common.properties.DoubleProperty;
+import xbot.common.properties.PropertyFactory;
+
+public class TrapezoidProfileManager {
+    
+    
+    final DoubleProperty maxVelocity;
+    final DoubleProperty maxAcceleration;
+    
+    TrapezoidProfile profile;
+    TrapezoidProfile.Constraints constraints;
+    TrapezoidProfile.State initialState;
+    TrapezoidProfile.State goalState;
+    Time profileStartTime = Seconds.zero(); 
+
+    public TrapezoidProfileManager(String name, PropertyFactory pf, double defaultMaxVelocity, double defaultMaxAcceleration, double initialPosition) { 
+        pf.setPrefix(name);
+        maxVelocity = pf.createPersistentProperty("maxVelocity", defaultMaxVelocity);
+        maxAcceleration = pf.createPersistentProperty("maxAcceleration", defaultMaxAcceleration);
+        constraints = new TrapezoidProfile.Constraints(maxVelocity.get(), maxAcceleration.get());
+        profile = new TrapezoidProfile(constraints);
+        // initialize states to current value
+        initialState = new TrapezoidProfile.State(initialPosition, 0);
+        goalState = new TrapezoidProfile.State(initialPosition, 0);
+    }
+
+    public void setTargetValue(double targetValue, double currentValue, double currentVelocity) {
+        // if the profile's constraints properties have changed, recompute the profile
+        // there's maybe a better place to do this but this should be fine since setTarget will be called
+        // over and over again
+        if(constraints.maxVelocity != maxVelocity.get() || constraints.maxAcceleration != maxAcceleration.get()) {
+            constraints = new TrapezoidProfile.Constraints(maxVelocity.get(), maxAcceleration.get());
+            profile = new TrapezoidProfile(constraints);
+        }
+
+        // if the target has changed, recompute the goal and current states
+        if(goalState.position != targetValue) {
+            initialState = new TrapezoidProfile.State(currentValue, currentVelocity);
+            goalState = new TrapezoidProfile.State(targetValue, 0);
+            profileStartTime = XTimer.getFPGATimestampTime();
+        }
+
+    }
+
+    // currently only doing position, but in theory this goal has a velocity associated with it too we could use
+    public double getCurrentPositionSetpoint() {
+        var setpoint = profile.calculate(XTimer.getFPGATimestampTime().minus(profileStartTime).in(Seconds), initialState, goalState);
+        return setpoint.position;
+    }
+    
+}

--- a/src/main/java/competition/simulation/elevator/ElevatorSimulator.java
+++ b/src/main/java/competition/simulation/elevator/ElevatorSimulator.java
@@ -2,6 +2,7 @@ package competition.simulation.elevator;
 
 import static edu.wpi.first.units.Units.Meters;
 import static edu.wpi.first.units.Units.Rotations;
+import static edu.wpi.first.units.Units.Seconds;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -77,9 +78,12 @@ public class ElevatorSimulator {
 
         // update the motor encoder position based on the elevator height, add in the
         // random from zero offset
+        var prevPosition = this.motor.getPosition();
         this.motor.setPosition(
                 Rotations.of(elevatorCurrentHeight.in(Meters) * ElevatorSimConstants.rotationsPerMeterHeight)
                         .plus(ElevatorSimConstants.rotationsAtZero));
+        // set the motors velocity based on change in position and the control loop time
+        this.motor.setVelocity(prevPosition.minus(this.motor.getPosition()).div(Seconds.of(SimulationConstants.loopPeriodSec)));
 
         // this would be used to simulate the bottom position sensor being triggered
         var elevatorIsAtBottom = elevatorCurrentHeight

--- a/src/main/java/competition/subsystems/elevator/ElevatorSubsystem.java
+++ b/src/main/java/competition/subsystems/elevator/ElevatorSubsystem.java
@@ -2,6 +2,7 @@ package competition.subsystems.elevator;
 
 import competition.electrical_contract.ElectricalContract;
 import edu.wpi.first.units.measure.Distance;
+import edu.wpi.first.units.measure.LinearVelocity;
 import xbot.common.command.BaseSetpointSubsystem;
 import xbot.common.controls.actuators.XCANMotorController;
 import xbot.common.properties.DoubleProperty;
@@ -14,7 +15,9 @@ import javax.inject.Singleton;
 import static edu.wpi.first.units.Units.Feet;
 import static edu.wpi.first.units.Units.Inches;
 import static edu.wpi.first.units.Units.Meters;
+import static edu.wpi.first.units.Units.MetersPerSecond;
 import static edu.wpi.first.units.Units.Rotations;
+import static edu.wpi.first.units.Units.RotationsPerSecond;
 
 @Singleton
 public class ElevatorSubsystem extends BaseSetpointSubsystem<Distance> {
@@ -30,7 +33,7 @@ public class ElevatorSubsystem extends BaseSetpointSubsystem<Distance> {
 
     final ElectricalContract contract;
 
-    private boolean isCalibrated; //set to true just for testing purposes
+    private boolean isCalibrated = true; //set to true just for testing purposes
     //TODO: Add a calibration routine
 
     public Distance elevatorTargetHeight;
@@ -100,6 +103,10 @@ public class ElevatorSubsystem extends BaseSetpointSubsystem<Distance> {
             currentHeight = Meters.of(this.masterMotor.getPosition().in(Rotations) * metersPerRotation.get()); //hastily written code will clean up later
         }
         return currentHeight;
+    }
+
+    public LinearVelocity getCurrentVelocity() {
+        return MetersPerSecond.of(masterMotor.getVelocity().in(RotationsPerSecond) * metersPerRotation.get());
     }
 
     @Override

--- a/src/main/java/competition/subsystems/elevator/ElevatorSubsystem.java
+++ b/src/main/java/competition/subsystems/elevator/ElevatorSubsystem.java
@@ -33,7 +33,8 @@ public class ElevatorSubsystem extends BaseSetpointSubsystem<Distance> {
 
     final ElectricalContract contract;
 
-    private boolean isCalibrated = true; //set to true just for testing purposes
+    // elevator starts uncalibrated because it could be in the middle of it's range and we have no idea where that is
+    private boolean isCalibrated;
     //TODO: Add a calibration routine
 
     public Distance elevatorTargetHeight;

--- a/src/main/java/competition/subsystems/elevator/commands/ElevatorMaintainerCommand.java
+++ b/src/main/java/competition/subsystems/elevator/commands/ElevatorMaintainerCommand.java
@@ -67,7 +67,11 @@ public class ElevatorMaintainerCommand extends BaseMaintainerCommand<Distance> {
     @Override
     protected void calibratedMachineControlAction() {
 
-        profileManager.setTargetValue(elevator.getTargetValue().in(Meters), elevator.getCurrentValue().in(Meters), elevator.getCurrentVelocity().in(MetersPerSecond));
+        profileManager.setTargetValue(
+            elevator.getTargetValue().in(Meters),
+            elevator.getCurrentValue().in(Meters),
+            elevator.getCurrentVelocity().in(MetersPerSecond)
+        );
         var setpoint = profileManager.getCurrentPositionSetpoint();
 
         // it's helpful to log this to know where the robot is actually trying to get to in the moment

--- a/src/main/java/competition/subsystems/elevator/commands/ElevatorMaintainerCommand.java
+++ b/src/main/java/competition/subsystems/elevator/commands/ElevatorMaintainerCommand.java
@@ -67,12 +67,12 @@ public class ElevatorMaintainerCommand extends BaseMaintainerCommand<Distance> {
     @Override
     protected void calibratedMachineControlAction() {
 
-        profileManager.setTargetValue(
+        profileManager.setTargetPosition(
             elevator.getTargetValue().in(Meters),
             elevator.getCurrentValue().in(Meters),
             elevator.getCurrentVelocity().in(MetersPerSecond)
         );
-        var setpoint = profileManager.getCurrentPositionSetpoint();
+        var setpoint = profileManager.getRecommendedPositionForTime();
 
         // it's helpful to log this to know where the robot is actually trying to get to in the moment
         aKitLog.record("elevatorProfileTarget", setpoint);

--- a/src/main/java/competition/subsystems/elevator/commands/ElevatorMaintainerCommand.java
+++ b/src/main/java/competition/subsystems/elevator/commands/ElevatorMaintainerCommand.java
@@ -3,21 +3,16 @@ package competition.subsystems.elevator.commands;
 import competition.motion.TrapezoidProfileManager;
 import competition.operator_interface.OperatorInterface;
 import competition.subsystems.elevator.ElevatorSubsystem;
-import edu.wpi.first.math.trajectory.TrapezoidProfile;
 import edu.wpi.first.units.measure.Distance;
 import xbot.common.command.BaseMaintainerCommand;
-import xbot.common.controls.sensors.XTimer;
 import xbot.common.logic.HumanVsMachineDecider;
 import xbot.common.math.MathUtils;
 import xbot.common.math.PIDManager;
 import xbot.common.properties.DoubleProperty;
 import xbot.common.properties.PropertyFactory;
 
-import static edu.wpi.first.units.Units.Inches;
-import static edu.wpi.first.units.Units.Meter;
 import static edu.wpi.first.units.Units.Meters;
 import static edu.wpi.first.units.Units.MetersPerSecond;
-import static edu.wpi.first.units.Units.Rotations;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
@@ -50,7 +45,7 @@ public class ElevatorMaintainerCommand extends BaseMaintainerCommand<Distance> {
         var pf = pfProvider.get();
         pf.setPrefix(this);
         this.elevator = elevator;
-        profileManager = new TrapezoidProfileManager(getPrefix() + "/trapezoidMotion", pfProvider.get(), 1, 1, elevator.getCurrentValue().in(Meters));
+        profileManager = new TrapezoidProfileManager(getPrefix() + "trapezoidMotion", pfProvider.get(), 1, 1, elevator.getCurrentValue().in(Meters));
 
         this.oi = oi;
         positionPID = pidf.create(getPrefix() + "positionPID", 0.00, 0, 0.0);
@@ -74,6 +69,8 @@ public class ElevatorMaintainerCommand extends BaseMaintainerCommand<Distance> {
 
         profileManager.setTargetValue(elevator.getTargetValue().in(Meters), elevator.getCurrentValue().in(Meters), elevator.getCurrentVelocity().in(MetersPerSecond));
         var setpoint = profileManager.getCurrentPositionSetpoint();
+
+        // it's helpful to log this to know where the robot is actually trying to get to in the moment
         aKitLog.record("elevatorProfileTarget", setpoint);
 
         double power = positionPID.calculate(


### PR DESCRIPTION
# Why are we doing this?

To enable smoother control of the elevator leverage https://docs.wpilib.org/en/stable/docs/software/advanced-controls/controllers/trapezoidal-profiles.html to limit the velocity and acceleration of system changes.

The goal here is to make this really easy to use so it's trivial to put it in our 3 positional systems (elevator, coral arm, pivot arm).

Asana task URL:

# Whats changing?

- Adds a new wrapper class for the wpilib trapezoid profile so that we can tune it with our Property system and plug it into our current pid logic easily
- This could be used with an on rio PID for position (as it is here) or the positional setpoint could just as easily be set on the motor controller itself

# Questions/notes for reviewers

- Should this live in the SetpointSubsystem instead perhaps? I just started in the maintainer because that's where the pid code was as I was hacking it in.

## Future work

- Could probably make an assisted factory for this so the PF doesn't need to be given in manually, lazy there to start
- Add this to the coral and algae arm systems too when the dust settles

# How this was tested
- [ ] unit tests added
- [ ] tested on robot

Tested in simulator

## Here's slow constraints causing very slow exaggerated motion as a demo:

https://github.com/user-attachments/assets/b91f8d94-b275-4c8d-a92b-319b03867123



## Changing the max accel or velocity changing the shape of the curve:
![image](https://github.com/user-attachments/assets/230fb1b8-8b13-4cbf-9c54-2f79046c39d5)


-----

PR feedback legend

 
| Symbol | Meaning                  |
|--------|--------------------------|
| :star: :star: :star:     | must be addressed                 |
| :star: :star:     | should be addressed        |
| :star:     | something to consider, a good idea                  |
