### PR TITLE
Add SysId routines for the Swerve drive

### DIFF
--- a/src/main/java/competition/operator_interface/OperatorCommandMap.java
+++ b/src/main/java/competition/operator_interface/OperatorCommandMap.java
@@ -20,6 +20,7 @@ import competition.subsystems.elevator.commands.ForceElevatorCalibratedCommand;
 import competition.subsystems.elevator.commands.SetElevatorTargetHeightCommand;
 
 import edu.wpi.first.wpilibj2.command.DeferredCommand;
+import edu.wpi.first.wpilibj2.command.WaitCommand;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine;
 
 import xbot.common.controls.sensors.XXboxController;
@@ -27,6 +28,8 @@ import xbot.common.subsystems.drive.swerve.commands.ChangeActiveSwerveModuleComm
 import xbot.common.subsystems.pose.commands.SetRobotHeadingCommand;
 
 import java.util.Set;
+
+import static edu.wpi.first.units.Units.Seconds;
 
 /**
  * Maps operator interface buttons to commands
@@ -55,7 +58,6 @@ public class OperatorCommandMap {
             DebugSwerveModuleCommand debugModule,
             ChangeActiveSwerveModuleCommand changeActiveModule,
             SwerveDriveWithJoysticksCommand typicalSwerveDrive,
-            DriveSubsystem drive,
             IntakeCoralCommand intakeCoralCommand,
             ScoreCoralCommand scoreCoralCommand,
             StopCoralCommand stopCoralCommand,
@@ -79,15 +81,6 @@ public class OperatorCommandMap {
         oi.programmerGamepad.getPovIfAvailable(90).onTrue(debugModule);
         oi.programmerGamepad.getPovIfAvailable(180).onTrue(typicalSwerveDrive);
 
-        oi.programmerGamepad.getifAvailable(XXboxController.XboxButton.LeftBumper)
-                .whileTrue(new DeferredCommand(() -> drive.getActiveSwerveModuleSubsystem()
-                        .getSteeringSubsystem()
-                        .sysIdQuasistatic(SysIdRoutine.Direction.kForward), Set.of()));
-        oi.programmerGamepad.getifAvailable(XXboxController.XboxButton.RightBumper)
-                .whileTrue(new DeferredCommand(() -> drive.getActiveSwerveModuleSubsystem()
-                        .getSteeringSubsystem()
-                        .sysIdQuasistatic(SysIdRoutine.Direction.kReverse), Set.of()));
-
         oi.programmerGamepad.getifAvailable(XXboxController.XboxButton.LeftTrigger).whileTrue(intakeCoralCommand);
         oi.programmerGamepad.getifAvailable(XXboxController.XboxButton.RightTrigger).whileTrue(scoreCoralCommand);
 
@@ -99,6 +92,40 @@ public class OperatorCommandMap {
 
 //        oi.programmerGamepad.getifAvailable(XXboxController.XboxButton.X).whileTrue(algaeCollectionIntakeCommand);
 //        oi.programmerGamepad.getifAvailable(XXboxController.XboxButton.B).whileTrue(algaeCollectionOutputCommand);
+
+    }
+
+    @Inject
+    public void setupSysIdCommands(
+        OperatorInterface oi,
+        DriveSubsystem drive
+    ) {
+        oi.sysIdGamepad.getifAvailable(XXboxController.XboxButton.A)
+                .whileTrue(drive.sysIdQuasistaticRotation(SysIdRoutine.Direction.kForward)
+                        .andThen(new WaitCommand(Seconds.of(1)))
+                        .andThen(drive.sysIdQuasistaticRotation(SysIdRoutine.Direction.kReverse))
+                        .andThen(new WaitCommand(Seconds.of(1)))
+                        .andThen(drive.sysIdDynamicRotation(SysIdRoutine.Direction.kForward))
+                        .andThen(new WaitCommand(Seconds.of(1)))
+                        .andThen(drive.sysIdDynamicRotation(SysIdRoutine.Direction.kReverse)));
+        oi.sysIdGamepad.getifAvailable(XXboxController.XboxButton.B)
+                .whileTrue(drive.sysIdQuasistaticDrive(SysIdRoutine.Direction.kForward)
+                        .andThen(new WaitCommand(Seconds.of(1)))
+                        .andThen(drive.sysIdQuasistaticDrive(SysIdRoutine.Direction.kReverse))
+                        .andThen(new WaitCommand(Seconds.of(1)))
+                        .andThen(drive.sysIdDynamicDrive(SysIdRoutine.Direction.kForward))
+                        .andThen(new WaitCommand(Seconds.of(1)))
+                        .andThen(drive.sysIdDynamicDrive(SysIdRoutine.Direction.kReverse)));
+
+        // Not used, but leaving these here as a sample of how to use a DeferredCommand
+//        oi.sysIdGamepad.getifAvailable(XXboxController.XboxButton.LeftBumper)
+//                .whileTrue(new DeferredCommand(() -> drive.getActiveSwerveModuleSubsystem()
+//                        .getSteeringSubsystem()
+//                        .sysIdQuasistatic(SysIdRoutine.Direction.kForward), Set.of()));
+//        oi.sysIdGamepad.getifAvailable(XXboxController.XboxButton.RightBumper)
+//                .whileTrue(new DeferredCommand(() -> drive.getActiveSwerveModuleSubsystem()
+//                        .getSteeringSubsystem()
+//                        .sysIdQuasistatic(SysIdRoutine.Direction.kReverse), Set.of()));
 
     }
 

--- a/src/main/java/competition/operator_interface/OperatorInterface.java
+++ b/src/main/java/competition/operator_interface/OperatorInterface.java
@@ -17,6 +17,7 @@ import xbot.common.properties.PropertyFactory;
 public class OperatorInterface {
     public XXboxController gamepad;
     public XXboxController programmerGamepad;
+    public XXboxController sysIdGamepad;
 
     final DoubleProperty driverDeadband;
     final DoubleProperty operatorDeadband;
@@ -30,6 +31,10 @@ public class OperatorInterface {
         programmerGamepad = controllerFactory.create(3);
         programmerGamepad.setLeftInversion(false, true);
         programmerGamepad.setRightInversion(true, true);
+
+        sysIdGamepad = controllerFactory.create(5);
+        sysIdGamepad.setLeftInversion(false, true);
+        sysIdGamepad.setRightInversion(true, true);
 
         pf.setPrefix("OperatorInterface");
         driverDeadband = pf.createPersistentProperty("Driver Deadband", 0.12);

--- a/src/main/java/competition/subsystems/drive/DriveSubsystem.java
+++ b/src/main/java/competition/subsystems/drive/DriveSubsystem.java
@@ -5,7 +5,10 @@ import javax.inject.Singleton;
 
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.units.measure.Voltage;
+import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
+import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import xbot.common.injection.swerve.FrontLeftDrive;
@@ -14,11 +17,16 @@ import xbot.common.injection.swerve.RearLeftDrive;
 import xbot.common.injection.swerve.RearRightDrive;
 import xbot.common.injection.swerve.SwerveComponent;
 import xbot.common.math.PIDManager.PIDManagerFactory;
+import xbot.common.math.XYPair;
 import xbot.common.properties.Property;
 import xbot.common.properties.PropertyFactory;
 import xbot.common.subsystems.drive.BaseSwerveDriveSubsystem;
 
 import java.util.function.Supplier;
+
+import static edu.wpi.first.units.Units.Second;
+import static edu.wpi.first.units.Units.Seconds;
+import static edu.wpi.first.units.Units.Volts;
 
 @Singleton
 public class DriveSubsystem extends BaseSwerveDriveSubsystem {
@@ -28,6 +36,9 @@ public class DriveSubsystem extends BaseSwerveDriveSubsystem {
     private Rotation2d staticHeadingTarget = new Rotation2d(); // The heading you want to constantly be at
     private boolean lookAtPointActive = false;
     private boolean staticHeadingActive = false;
+
+    private final SysIdRoutine sysIdDrive;
+    private final SysIdRoutine sysIdRotation;
 
     @Inject
     public DriveSubsystem(PIDManagerFactory pidFactory, PropertyFactory pf,
@@ -39,6 +50,32 @@ public class DriveSubsystem extends BaseSwerveDriveSubsystem {
 
         pf.setPrefix(this.getPrefix());
         pf.setDefaultLevel(Property.PropertyLevel.Important);
+
+        this.sysIdDrive = new SysIdRoutine(
+                new SysIdRoutine.Config(
+                        Volts.of(getMaxTargetSpeedMetersPerSecond() / 5).per(Second),
+                        Volts.of(getMaxTargetSpeedMetersPerSecond()),
+                        Seconds.of(6),
+                        (state) -> org.littletonrobotics.junction.Logger.recordOutput(this.getPrefix() + "/SysIdState-Drive", state.toString())),
+                new SysIdRoutine.Mechanism(
+                        (Voltage volts) -> move(new XYPair(volts.in(Volts), 0), 0),
+                        null,
+                        this
+                )
+        );
+
+        this.sysIdRotation = new SysIdRoutine(
+                new SysIdRoutine.Config(
+                        Volts.of(getMaxTargetTurnRate() / 5).per(Second),
+                        Volts.of(getMaxTargetTurnRate()),
+                        Seconds.of(6),
+                        (state) -> org.littletonrobotics.junction.Logger.recordOutput(this.getPrefix() + "/SysIdState-Rotation", state.toString())),
+                new SysIdRoutine.Mechanism(
+                        (Voltage volts) -> move(new XYPair(), volts.in(Volts)),
+                        null,
+                        this
+                )
+        );
     }
 
     public Translation2d getLookAtPointTarget() {
@@ -92,5 +129,41 @@ public class DriveSubsystem extends BaseSwerveDriveSubsystem {
             setStaticHeadingTargetActive(false);
             setLookAtPointTargetActive(false);
         });
+    }
+
+    /**
+     * Gets a command to run the SysId drive routine in the quasistatic mode.
+     * @param direction The direction to run the SysId routine.
+     * @return The command to run the SysId routine.
+     */
+    public Command sysIdQuasistaticDrive(SysIdRoutine.Direction direction) {
+        return sysIdDrive.quasistatic(direction);
+    }
+
+    /**
+     * Gets a command to run the SysId drive routine in the dynamic mode.
+     * @param direction The direction to run the SysId routine.
+     * @return The command to run the SysId routine.
+     */
+    public Command sysIdDynamicDrive(SysIdRoutine.Direction direction) {
+        return sysIdDrive.dynamic(direction);
+    }
+
+    /**
+     * Gets a command to run the SysId rotation routine in the quasistatic mode.
+     * @param direction The direction to run the SysId routine.
+     * @return The command to run the SysId routine.
+     */
+    public Command sysIdQuasistaticRotation(SysIdRoutine.Direction direction) {
+        return sysIdRotation.quasistatic(direction);
+    }
+
+    /**
+     * Gets a command to run the SysId rotation routine in the dynamic mode.
+     * @param direction The direction to run the SysId routine.
+     * @return The command to run the SysId routine.
+     */
+    public Command sysIdDynamicRotation(SysIdRoutine.Direction direction) {
+        return sysIdRotation.dynamic(direction);
     }
 }


### PR DESCRIPTION
# Why are we doing this?
We need a practical SysId example to try it out.

Asana task URL:

# Whats changing?
Add a SysId gamepad to allow us to tune the pids for the robot drive.

# Questions/notes for reviewers

# How this was tested
- [ ] tested on robot
- [x] tested in simulator
- [ ] unit tests added

## Video/screenshots (from simulator or live robot)

-----

PR feedback legend

 
| Symbol | Meaning                  |
|--------|--------------------------|
| :star: :star: :star:     | must be addressed                 |
| :star: :star:     | should be addressed        |
| :star:     | something to consider, a good idea                  |
