### PR TITLE
Move to clear responsibilities for gamepads

### DIFF
--- a/src/main/java/competition/operator_interface/OperatorCommandMap.java
+++ b/src/main/java/competition/operator_interface/OperatorCommandMap.java
@@ -19,15 +19,12 @@ import competition.subsystems.elevator.ElevatorSubsystem;
 import competition.subsystems.elevator.commands.ForceElevatorCalibratedCommand;
 import competition.subsystems.elevator.commands.SetElevatorTargetHeightCommand;
 
-import edu.wpi.first.wpilibj2.command.DeferredCommand;
 import edu.wpi.first.wpilibj2.command.WaitCommand;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine;
 
 import xbot.common.controls.sensors.XXboxController;
 import xbot.common.subsystems.drive.swerve.commands.ChangeActiveSwerveModuleCommand;
 import xbot.common.subsystems.pose.commands.SetRobotHeadingCommand;
-
-import java.util.Set;
 
 import static edu.wpi.first.units.Units.Seconds;
 
@@ -46,7 +43,7 @@ public class OperatorCommandMap {
             OperatorInterface operatorInterface,
             SetRobotHeadingCommand resetHeading) {
         resetHeading.setHeadingToApply(0);
-        operatorInterface.gamepad.getifAvailable(1).onTrue(resetHeading);
+        operatorInterface.driverGamepad.getifAvailable(1).onTrue(resetHeading);
     }
 
     // Programmer commands are only meant to be used to debug or test the robot. They should not be used in competition,
@@ -77,18 +74,18 @@ public class OperatorCommandMap {
         var riseToL4 = setElevatorTargetHeightCommandProvider.get();
         riseToL4.setHeight(ElevatorSubsystem.ElevatorGoals.ScoreL4);
 
-        oi.programmerGamepad.getPovIfAvailable(0).onTrue(changeActiveModule);
-        oi.programmerGamepad.getPovIfAvailable(90).onTrue(debugModule);
-        oi.programmerGamepad.getPovIfAvailable(180).onTrue(typicalSwerveDrive);
+        oi.superstructureGamepad.getPovIfAvailable(0).onTrue(changeActiveModule);
+        oi.superstructureGamepad.getPovIfAvailable(90).onTrue(debugModule);
+        oi.superstructureGamepad.getPovIfAvailable(180).onTrue(typicalSwerveDrive);
 
-        oi.programmerGamepad.getifAvailable(XXboxController.XboxButton.LeftTrigger).whileTrue(intakeCoralCommand);
-        oi.programmerGamepad.getifAvailable(XXboxController.XboxButton.RightTrigger).whileTrue(scoreCoralCommand);
+        oi.superstructureGamepad.getifAvailable(XXboxController.XboxButton.LeftTrigger).whileTrue(intakeCoralCommand);
+        oi.superstructureGamepad.getifAvailable(XXboxController.XboxButton.RightTrigger).whileTrue(scoreCoralCommand);
 
-        oi.programmerGamepad.getifAvailable(XXboxController.XboxButton.Start).onTrue(forceElevatorCalibratedCommand);
-        oi.programmerGamepad.getifAvailable(XXboxController.XboxButton.B).whileTrue(riseToL2);
-        oi.programmerGamepad.getifAvailable(XXboxController.XboxButton.A).whileTrue(riseToL3);
-        oi.programmerGamepad.getifAvailable(XXboxController.XboxButton.X).whileTrue(riseToL4);
-        oi.programmerGamepad.getifAvailable(XXboxController.XboxButton.Y).whileTrue(riseToL1);
+        oi.superstructureGamepad.getifAvailable(XXboxController.XboxButton.Start).onTrue(forceElevatorCalibratedCommand);
+        oi.superstructureGamepad.getifAvailable(XXboxController.XboxButton.B).whileTrue(riseToL2);
+        oi.superstructureGamepad.getifAvailable(XXboxController.XboxButton.A).whileTrue(riseToL3);
+        oi.superstructureGamepad.getifAvailable(XXboxController.XboxButton.X).whileTrue(riseToL4);
+        oi.superstructureGamepad.getifAvailable(XXboxController.XboxButton.Y).whileTrue(riseToL1);
 
 //        oi.programmerGamepad.getifAvailable(XXboxController.XboxButton.X).whileTrue(algaeCollectionIntakeCommand);
 //        oi.programmerGamepad.getifAvailable(XXboxController.XboxButton.B).whileTrue(algaeCollectionOutputCommand);
@@ -100,7 +97,7 @@ public class OperatorCommandMap {
         OperatorInterface oi,
         DriveSubsystem drive
     ) {
-        oi.sysIdGamepad.getifAvailable(XXboxController.XboxButton.A)
+        oi.algaeAndSysIdGamepad.getifAvailable(XXboxController.XboxButton.A)
                 .whileTrue(drive.sysIdQuasistaticRotation(SysIdRoutine.Direction.kForward)
                         .andThen(new WaitCommand(Seconds.of(1)))
                         .andThen(drive.sysIdQuasistaticRotation(SysIdRoutine.Direction.kReverse))
@@ -108,7 +105,7 @@ public class OperatorCommandMap {
                         .andThen(drive.sysIdDynamicRotation(SysIdRoutine.Direction.kForward))
                         .andThen(new WaitCommand(Seconds.of(1)))
                         .andThen(drive.sysIdDynamicRotation(SysIdRoutine.Direction.kReverse)));
-        oi.sysIdGamepad.getifAvailable(XXboxController.XboxButton.B)
+        oi.algaeAndSysIdGamepad.getifAvailable(XXboxController.XboxButton.B)
                 .whileTrue(drive.sysIdQuasistaticDrive(SysIdRoutine.Direction.kForward)
                         .andThen(new WaitCommand(Seconds.of(1)))
                         .andThen(drive.sysIdQuasistaticDrive(SysIdRoutine.Direction.kReverse))

--- a/src/main/java/competition/operator_interface/OperatorInterface.java
+++ b/src/main/java/competition/operator_interface/OperatorInterface.java
@@ -15,10 +15,12 @@ import xbot.common.properties.PropertyFactory;
  */
 @Singleton
 public class OperatorInterface {
-    public final XXboxController gamepad;
-    public final XXboxController programmerGamepad;
-    public final XXboxController algaeArmGamepad;
-    public final XXboxController sysIdGamepad;
+    public final XXboxController driverGamepad;
+    public final XXboxController operatorGamepad;
+    public final XXboxController neoTrellis;
+    public final XXboxController oiPanel;
+    public final XXboxController superstructureGamepad;
+    public final XXboxController algaeAndSysIdGamepad;
 
     final DoubleProperty driverDeadband;
     final DoubleProperty operatorDeadband;
@@ -28,21 +30,27 @@ public class OperatorInterface {
 
     @Inject
     public OperatorInterface(XXboxControllerFactory controllerFactory, RobotAssertionManager assertionManager, PropertyFactory pf) {
-        gamepad = controllerFactory.create(0);
-        gamepad.setLeftInversion(false, true);
-        gamepad.setRightInversion(true, true);
+        driverGamepad = controllerFactory.create(0);
+        driverGamepad.setLeftInversion(false, true);
+        driverGamepad.setRightInversion(true, true);
 
-        programmerGamepad = controllerFactory.create(3);
-        programmerGamepad.setLeftInversion(false, true);
-        programmerGamepad.setRightInversion(true, true);
+        operatorGamepad = controllerFactory.create(1);
+        operatorGamepad.setLeftInversion(false, true);
+        operatorGamepad.setRightInversion(false, true);
 
-        algaeArmGamepad=controllerFactory.create(5);
-        algaeArmGamepad.setLeftInversion(false,true);
-        algaeArmGamepad.setRightInversion(true,true);
+        neoTrellis = controllerFactory.create(2);
+        // No axes to invert on the NeoTrellis
 
-        sysIdGamepad = controllerFactory.create(6);
-        sysIdGamepad.setLeftInversion(false, true);
-        sysIdGamepad.setRightInversion(true, true);
+        oiPanel = controllerFactory.create(3);
+        // No axes to invert on the OI Panel
+
+        superstructureGamepad = controllerFactory.create(4);
+        superstructureGamepad.setLeftInversion(false, true);
+        superstructureGamepad.setRightInversion(false, true);
+
+        algaeAndSysIdGamepad=controllerFactory.create(5);
+        algaeAndSysIdGamepad.setLeftInversion(false, true);
+        algaeAndSysIdGamepad.setRightInversion(false, true);
 
         pf.setPrefix("OperatorInterface");
         driverDeadband = pf.createPersistentProperty("Driver Deadband", 0.12);
@@ -56,8 +64,5 @@ public class OperatorInterface {
 
     public double getOperatorGamepadTypicalDeadband() {
         return operatorDeadband.get();
-    }
-    public double getAlgaeArmGamepadTypicalDeadband(){
-        return algaeArmDeadband.get();
     }
 }

--- a/src/main/java/competition/subsystems/algae_arm/commands/AlgaeArmMaintainerCommand.java
+++ b/src/main/java/competition/subsystems/algae_arm/commands/AlgaeArmMaintainerCommand.java
@@ -63,8 +63,8 @@ public class AlgaeArmMaintainerCommand extends BaseMaintainerCommand<Angle> {
     protected double getHumanInput() {
         return MathUtils.constrainDouble(
                 MathUtils.deadband(
-                        oi.algaeArmGamepad.getRightStickY(),
-                        oi.getAlgaeArmGamepadTypicalDeadband(),
+                        oi.algaeAndSysIdGamepad.getRightStickY(),
+                        oi.getOperatorGamepadTypicalDeadband(),
                         (a) -> (a)),
                 humanMinPower.get(), humanMaxPower.get());
     }

--- a/src/main/java/competition/subsystems/coral_arm_pivot/commands/CoralArmPivotMaintainerCommand.java
+++ b/src/main/java/competition/subsystems/coral_arm_pivot/commands/CoralArmPivotMaintainerCommand.java
@@ -67,7 +67,7 @@ public class CoralArmPivotMaintainerCommand extends BaseMaintainerCommand<Angle>
     protected double getHumanInput() { //gamepad controls: Left joy stick up/down & Left bumper to switch between elevator/arm
        return MathUtils.constrainDouble(
                MathUtils.deadband(
-                       oi.programmerGamepad.getRightStickY(),
+                       oi.superstructureGamepad.getRightStickY(),
                        oi.getOperatorGamepadTypicalDeadband(),
                        (a) -> (a)),
                humanMinPower.get(), humanMaxPower.get());

--- a/src/main/java/competition/subsystems/drive/commands/DebugSwerveModuleCommand.java
+++ b/src/main/java/competition/subsystems/drive/commands/DebugSwerveModuleCommand.java
@@ -26,8 +26,8 @@ public class DebugSwerveModuleCommand extends BaseCommand {
 
     @Override
     public void execute() {
-        double drivePower = MathUtil.applyDeadband(oi.programmerGamepad.getLeftStickY(), oi.getDriverGamepadTypicalDeadband());
-        double turnPower = MathUtil.applyDeadband(oi.programmerGamepad.getRightStickX(), oi.getDriverGamepadTypicalDeadband());
+        double drivePower = MathUtil.applyDeadband(oi.superstructureGamepad.getLeftStickY(), oi.getDriverGamepadTypicalDeadband());
+        double turnPower = MathUtil.applyDeadband(oi.superstructureGamepad.getRightStickX(), oi.getDriverGamepadTypicalDeadband());
 
         drive.controlOnlyActiveSwerveModuleSubsystem(drivePower, turnPower);
     }

--- a/src/main/java/competition/subsystems/drive/commands/SwerveDriveWithJoysticksCommand.java
+++ b/src/main/java/competition/subsystems/drive/commands/SwerveDriveWithJoysticksCommand.java
@@ -83,8 +83,8 @@ public class SwerveDriveWithJoysticksCommand extends BaseCommand {
     }
 
     private XYPair getRawHumanTranslationIntent() {
-        double xIntent = MathUtils.deadband(oi.gamepad.getLeftVector().getX(), 0.15);
-        double yIntent = MathUtils.deadband(oi.gamepad.getLeftVector().getY(), 0.15);
+        double xIntent = MathUtils.deadband(oi.driverGamepad.getLeftVector().getX(), 0.15);
+        double yIntent = MathUtils.deadband(oi.driverGamepad.getLeftVector().getY(), 0.15);
 
         XYPair translationIntent = new XYPair(xIntent, yIntent);
 
@@ -98,8 +98,8 @@ public class SwerveDriveWithJoysticksCommand extends BaseCommand {
 
     private double getRawHumanRotationIntent() {
         // Deadband is to prevent buggy joysticks/triggers
-        double rotateLeftIntent = MathUtils.deadband(oi.gamepad.getLeftTrigger(), 0.05);
-        double rotateRightIntent = MathUtils.deadband(oi.gamepad.getRightTrigger(), 0.05);
+        double rotateLeftIntent = MathUtils.deadband(oi.driverGamepad.getLeftTrigger(), 0.05);
+        double rotateRightIntent = MathUtils.deadband(oi.driverGamepad.getRightTrigger(), 0.05);
 
         // Merge the two trigger values together in case of conflicts
         // Rotate left = positive, right = negative
@@ -110,7 +110,7 @@ public class SwerveDriveWithJoysticksCommand extends BaseCommand {
         // Checks the right joystick input to see if we want to snap to a certain side
         // Apparently, we need to invert the x input here as it has been inverted for other commands already
         // And of course, we must rotate -90 (similar to how we got raw translation) for default alignment
-        XYPair joystickInput = new XYPair(-oi.gamepad.getRightVector().getX(), oi.gamepad.getRightVector().getY()).rotate(-90);
+        XYPair joystickInput = new XYPair(-oi.driverGamepad.getRightVector().getX(), oi.driverGamepad.getRightVector().getY()).rotate(-90);
 
         SwerveSuggestedRotation suggested = advisor.getSuggestedRotationValue(joystickInput, triggerRotateIntent);
         return processSuggestedRotationValueIntoPower(suggested);

--- a/src/main/java/competition/subsystems/drive/commands/TankDriveWithJoysticksCommand.java
+++ b/src/main/java/competition/subsystems/drive/commands/TankDriveWithJoysticksCommand.java
@@ -28,8 +28,8 @@ public class TankDriveWithJoysticksCommand extends BaseCommand {
     @Override
     public void execute() {
         driveSubsystem.tankDrive(
-            MathUtils.deadband(oi.gamepad.getLeftVector().getY(), 0.15), 
-            MathUtils.deadband(oi.gamepad.getRightVector().getX(), 0.15)
+            MathUtils.deadband(oi.driverGamepad.getLeftVector().getY(), 0.15),
+            MathUtils.deadband(oi.driverGamepad.getRightVector().getX(), 0.15)
         );
     }
 }

--- a/src/main/java/competition/subsystems/elevator/commands/ElevatorMaintainerCommand.java
+++ b/src/main/java/competition/subsystems/elevator/commands/ElevatorMaintainerCommand.java
@@ -110,7 +110,7 @@ public class ElevatorMaintainerCommand extends BaseMaintainerCommand<Distance> {
     protected double getHumanInput() {
         return MathUtils.constrainDouble(
                 MathUtils.deadband(
-                    oi.programmerGamepad.getLeftVector().getY(),
+                    oi.superstructureGamepad.getLeftVector().getY(),
                     oi.getOperatorGamepadTypicalDeadband(),
                     (a) -> (a)),
                 humanMaxPowerGoingDown.get(), humanMaxPowerGoingUp.get());


### PR DESCRIPTION
# Why are we doing this?
New pattern for gamepads:
 - 1) Driver
 - 2) Operator (xbox controller)
 - 3) Neotrellis
 - 4) OI Panel
 - 5) ManualOverrides - Superstructure (Elevator, Arm)
 - 6) ManualOverrides - AlgaeArm and SysId
Asana task URL:

# Whats changing?

# Questions/notes for reviewers

# How this was tested
- [ ] tested on robot
- [ ] tested in simulator
- [ ] unit tests added

## Video/screenshots (from simulator or live robot)

-----

PR feedback legend

 
| Symbol | Meaning                  |
|--------|--------------------------|
| :star: :star: :star:     | must be addressed                 |
| :star: :star:     | should be addressed        |
| :star:     | something to consider, a good idea                  |
