### PR TITLE
Add a test that will verify that all subsystems with motor controller…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,6 +99,8 @@ dependencies {
     annotationProcessor 'com.google.dagger:dagger-compiler:2.44.2'
     testAnnotationProcessor 'com.google.dagger:dagger-compiler:2.44.2'
 
+    testImplementation "org.mockito:mockito-core:3.+"
+
     def akitJson = new groovy.json.JsonSlurper().parseText(new File(projectDir.getAbsolutePath() + "/vendordeps/AdvantageKit.json").text)
     annotationProcessor "org.littletonrobotics.akit:akit-autolog:$akitJson.version"
 }

--- a/src/main/java/competition/subsystems/coral_arm_pivot/CoralArmPivotSubsystem.java
+++ b/src/main/java/competition/subsystems/coral_arm_pivot/CoralArmPivotSubsystem.java
@@ -192,6 +192,10 @@ public class CoralArmPivotSubsystem extends BaseSetpointSubsystem<Angle> {
 
     @Override
     public void periodic() {
+        if (electricalContract.isArmPivotMotorReady()) {
+            armMotor.periodic();
+        }
+
         aKitLog.record("Target Angle", this.getTargetValue().in(Degrees));
         aKitLog.record("Current Angle", this.getCurrentValue().in(Degrees));
     }

--- a/src/main/java/competition/subsystems/drive/commands/DriveToNearestReefFaceCommand.java
+++ b/src/main/java/competition/subsystems/drive/commands/DriveToNearestReefFaceCommand.java
@@ -6,6 +6,7 @@ import competition.subsystems.pose.PoseSubsystem;
 import competition.subsystems.vision.AprilTagVisionSubsystemExtended;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.wpilibj.DriverStation;
+import xbot.common.logging.RobotAssertionManager;
 import xbot.common.properties.PropertyFactory;
 import xbot.common.subsystems.drive.SwerveSimpleTrajectoryCommand;
 import xbot.common.subsystems.drive.control_logic.HeadingModule;
@@ -25,8 +26,9 @@ public class DriveToNearestReefFaceCommand extends SwerveSimpleTrajectoryCommand
     @Inject
     public DriveToNearestReefFaceCommand(DriveSubsystem drive, PoseSubsystem pose, PropertyFactory pf,
                                          HeadingModule.HeadingModuleFactory headingModuleFactory,
-                                         AprilTagVisionSubsystemExtended aprilTagVisionSubsystem) {
-        super(drive, pose, pf, headingModuleFactory);
+                                         AprilTagVisionSubsystemExtended aprilTagVisionSubsystem,
+                                         RobotAssertionManager robotAssertionManager) {
+        super(drive, pose, pf, headingModuleFactory, robotAssertionManager);
         this.drive = drive;
         this.aprilTagVisionSubsystem = aprilTagVisionSubsystem;
         this.pose = pose;
@@ -41,7 +43,6 @@ public class DriveToNearestReefFaceCommand extends SwerveSimpleTrajectoryCommand
         ArrayList<XbotSwervePoint> swervePoints = new ArrayList<>();
         swervePoints.add(new XbotSwervePoint(targetReefFacePose, 10));
         this.logic.setKeyPoints(swervePoints);
-        this.logic.setEnableConstantVelocity(true);
         this.logic.setConstantVelocity(drive.getMaxTargetSpeedMetersPerSecond());
         super.initialize();
     }

--- a/src/test/java/competition/subsystems/GenericSubsystemTest.java
+++ b/src/test/java/competition/subsystems/GenericSubsystemTest.java
@@ -1,0 +1,78 @@
+package competition.subsystems;
+
+import competition.BaseCompetitionTest;
+import competition.subsystems.drive.DriveSubsystem;
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import org.junit.Test;
+import org.mockito.Mockito;
+import xbot.common.command.BaseSubsystem;
+import xbot.common.controls.actuators.XCANMotorController;
+import xbot.common.injection.BaseWPITest;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.fail;
+
+public class GenericSubsystemTest extends BaseCompetitionTest {
+
+    @Test
+    public void testAllSubsystemsCallPeriodicOnMotorControllers() throws Exception {
+        // Find all subsystem implementations via reflection
+        List<Object> subsystems = new ArrayList<>();
+        for (var injectorMethod : getInjectorComponent().getClass().getMethods()) {
+            if (injectorMethod.getParameterCount() != 0) {
+                continue;
+            }
+            if (BaseSubsystem.class.isAssignableFrom(injectorMethod.getReturnType())) {
+                injectorMethod.setAccessible(true);
+                subsystems.add(injectorMethod.invoke(getInjectorComponent()));
+            }
+        }
+        assertNotEquals(0, subsystems.size());
+
+        // For each subsystem, find all the motor controllers
+        for (Object subsystem : subsystems) {
+            List<Object> motorControllers = new ArrayList<>();
+            for (Field field : subsystem.getClass().getFields()) {
+                if (XCANMotorController.class.isAssignableFrom(field.getType())) {
+                    field.setAccessible(true);
+                    field.set(subsystem, Mockito.spy(field.get(subsystem)));
+                    // Replace the original motor controllers with the mocked ones
+                    motorControllers.add(field.get(subsystem));
+                }
+            }
+
+            if (motorControllers.isEmpty()) {
+                continue;
+            }
+
+            // Run each subsystem refreshDataFrame method
+            Method refreshDataFrameMethod = subsystem.getClass().getMethod("refreshDataFrame");
+            refreshDataFrameMethod.setAccessible(true);
+            try {
+                refreshDataFrameMethod.invoke(subsystem);
+            } catch (Exception e) {
+                fail("Subsystem " + subsystem.getClass().getName() + " failed to call refreshDataFrame:\n" + e);
+            }
+
+            // Run each subsystem periodic method
+            Method periodicMethod = subsystem.getClass().getMethod("periodic");
+            periodicMethod.setAccessible(true);
+            try {
+                periodicMethod.invoke(subsystem);
+            } catch (Exception e) {
+                fail("Subsystem " + subsystem.getClass().getName() + " failed to call periodic:\n" + e);
+            }
+
+            // Check that each motor controller periodic method was called
+            for (Object motorController : motorControllers) {
+                    Mockito.verify((XCANMotorController)motorController, Mockito.times(1)
+                            .description("Subsystem " + subsystem.getClass().getName() + " did not call periodic on a motor controller.")).periodic();
+            }
+        }
+    }
+}

--- a/src/test/java/competition/subsystems/GenericSubsystemTest.java
+++ b/src/test/java/competition/subsystems/GenericSubsystemTest.java
@@ -1,19 +1,17 @@
 package competition.subsystems;
 
 import competition.BaseCompetitionTest;
-import competition.subsystems.drive.DriveSubsystem;
-import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import org.junit.Test;
 import org.mockito.Mockito;
 import xbot.common.command.BaseSubsystem;
 import xbot.common.controls.actuators.XCANMotorController;
-import xbot.common.injection.BaseWPITest;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.fail;
@@ -44,7 +42,9 @@ public class GenericSubsystemTest extends BaseCompetitionTest {
             } catch (Exception e) {
                 fail("Subsystem " + subsystem.getClass().getName() + " failed to call refreshDataFrame:\n" + e);
             }
+        }
 
+        for (Object subsystem : subsystems) {
             // Run each subsystem periodic method
             Method periodicMethod = subsystem.getClass().getMethod("periodic");
             periodicMethod.setAccessible(true);
@@ -71,6 +71,8 @@ public class GenericSubsystemTest extends BaseCompetitionTest {
         }
         assertNotEquals(0, subsystems.size());
 
+        Map<Object, List<Object>> subsystemMotorControllerMap = new HashMap<>();
+
         // For each subsystem, find all the motor controllers
         for (Object subsystem : subsystems) {
             List<Object> motorControllers = new ArrayList<>();
@@ -82,12 +84,11 @@ public class GenericSubsystemTest extends BaseCompetitionTest {
                     motorControllers.add(field.get(subsystem));
                 }
             }
+            subsystemMotorControllerMap.put(subsystem, motorControllers);
+        }
 
-            if (motorControllers.isEmpty()) {
-                continue;
-            }
-
-            // Run each subsystem refreshDataFrame method
+        // Run each subsystem refreshDataFrame method
+        for (Object subsystem : subsystems) {
             Method refreshDataFrameMethod = subsystem.getClass().getMethod("refreshDataFrame");
             refreshDataFrameMethod.setAccessible(true);
             try {
@@ -95,8 +96,10 @@ public class GenericSubsystemTest extends BaseCompetitionTest {
             } catch (Exception e) {
                 fail("Subsystem " + subsystem.getClass().getName() + " failed to call refreshDataFrame:\n" + e);
             }
+        }
 
-            // Run each subsystem periodic method
+        // Run each subsystem periodic method
+        for (Object subsystem : subsystems) {
             Method periodicMethod = subsystem.getClass().getMethod("periodic");
             periodicMethod.setAccessible(true);
             try {
@@ -104,9 +107,11 @@ public class GenericSubsystemTest extends BaseCompetitionTest {
             } catch (Exception e) {
                 fail("Subsystem " + subsystem.getClass().getName() + " failed to call periodic:\n" + e);
             }
+        }
 
-            // Check that each motor controller periodic method was called
-            for (Object motorController : motorControllers) {
+        // Check that each motor controller periodic method was called
+        for (Object subsystem : subsystems) {
+            for (Object motorController : subsystemMotorControllerMap.get(subsystem)) {
                     Mockito.verify((XCANMotorController)motorController, Mockito.times(1)
                             .description("Subsystem " + subsystem.getClass().getName() + " did not call periodic on a motor controller.")).periodic();
             }


### PR DESCRIPTION
…s call periodic on those motor controllers.

# Why are we doing this?
If we don't call periodic on motor controllers in a subsystem, we won't get properties emitted in NetworkTables.

# Whats changing?
Add a test that gets all of the injected subsystems by reflection and checks if motor controllers have periodic called.

# Questions/notes for reviewers

# How this was tested
- [ ] tested on robot
- [ ] tested in simulator
- [x] unit tests added

## Video/screenshots (from simulator or live robot)

-----

PR feedback legend

 
| Symbol | Meaning                  |
|--------|--------------------------|
| :star: :star: :star:     | must be addressed                 |
| :star: :star:     | should be addressed        |
| :star:     | something to consider, a good idea                  |
