### PR TITLE
Align to reef fixes

### DIFF
--- a/src/main/java/competition/electrical_contract/Contract2025.java
+++ b/src/main/java/competition/electrical_contract/Contract2025.java
@@ -9,6 +9,7 @@ import edu.wpi.first.math.geometry.Translation3d;
 import edu.wpi.first.math.geometry.Rotation3d;
 
 import competition.subsystems.pose.PoseSubsystem;
+import edu.wpi.first.units.measure.Distance;
 import xbot.common.injection.electrical_contract.CANBusId;
 import xbot.common.injection.electrical_contract.CANMotorControllerInfo;
 import xbot.common.injection.electrical_contract.CANMotorControllerOutputConfig;
@@ -18,6 +19,8 @@ import xbot.common.injection.electrical_contract.MotorControllerType;
 import xbot.common.injection.swerve.SwerveInstance;
 import xbot.common.math.XYPair;
 import xbot.common.subsystems.vision.CameraCapabilities;
+
+import static edu.wpi.first.units.Units.Inches;
 
 public class Contract2025 extends ElectricalContract {
 
@@ -264,7 +267,7 @@ public class Contract2025 extends ElectricalContract {
     private static double aprilCameraYDisplacement = 12.972 / PoseSubsystem.INCHES_IN_A_METER;
     private static double aprilCameraZDisplacement = 9.014 / PoseSubsystem.INCHES_IN_A_METER;
     private static double aprilCameraPitch = Math.toRadians(0);
-    private static double aprilCameraYaw = Math.toRadians(10);
+    private static double aprilCameraYaw = Math.toRadians(0);
 
     public CameraInfo[] getCameraInfo() {
         return new CameraInfo[] {
@@ -277,5 +280,10 @@ public class Contract2025 extends ElectricalContract {
                                 new Rotation3d(0, aprilCameraPitch, aprilCameraYaw)),
                         EnumSet.of(CameraCapabilities.APRIL_TAG))
         };
+    }
+
+    @Override
+    public Distance getDistanceFromCenterToOuterBumperX() {
+        return Inches.of(18);
     }
 }

--- a/src/main/java/competition/electrical_contract/ElectricalContract.java
+++ b/src/main/java/competition/electrical_contract/ElectricalContract.java
@@ -1,5 +1,6 @@
 package competition.electrical_contract;
 
+import edu.wpi.first.units.measure.Distance;
 import xbot.common.controls.sensors.XDigitalInput;
 import xbot.common.injection.electrical_contract.CANMotorControllerInfo;
 import xbot.common.injection.electrical_contract.DeviceInfo;
@@ -63,5 +64,7 @@ public abstract class ElectricalContract implements XSwerveDriveElectricalContra
     public abstract CANMotorControllerInfo getAlgaeArmPivotMotor();
 
     public abstract boolean isAlgaeArmPivotMotorReady();
+
+    public abstract Distance getDistanceFromCenterToOuterBumperX();
 
 }

--- a/src/main/java/competition/operator_interface/OperatorCommandMap.java
+++ b/src/main/java/competition/operator_interface/OperatorCommandMap.java
@@ -16,6 +16,7 @@ import competition.subsystems.coral_scorer.commands.ScoreCoralCommand;
 import competition.subsystems.coral_scorer.commands.ScoreWhenReadyCommand;
 import competition.subsystems.coral_scorer.commands.StopCoralCommand;
 import competition.subsystems.drive.DriveSubsystem;
+import competition.subsystems.drive.commands.AlignToReefWithAprilTagCommand;
 import competition.subsystems.drive.commands.DebugSwerveModuleCommand;
 import competition.subsystems.drive.commands.SwerveDriveWithJoysticksCommand;
 
@@ -43,11 +44,13 @@ public class OperatorCommandMap {
     
     // Example for setting up a command to fire when a button is pressed:
     @Inject
-    public void setupMyCommands(
+    public void setupDriveCommands(
             OperatorInterface operatorInterface,
-            SetRobotHeadingCommand resetHeading) {
+            SetRobotHeadingCommand resetHeading,
+            AlignToReefWithAprilTagCommand alignToReefWithAprilTagCommand) {
         resetHeading.setHeadingToApply(0);
-        operatorInterface.driverGamepad.getifAvailable(1).onTrue(resetHeading);
+        operatorInterface.driverGamepad.getifAvailable(XXboxController.XboxButton.A).onTrue(resetHeading);
+        operatorInterface.driverGamepad.getifAvailable(XXboxController.XboxButton.X).whileTrue(alignToReefWithAprilTagCommand);
     }
 
     @Inject


### PR DESCRIPTION
# Why are we doing this?
Align to Reef had a few bugs, most critically relating to reusing PID for X and Y rather than PID'ding on a unified vector. Moved that key logic to the SCL and using it here.
Asana task URL:

# What's changing?
* Robot now tracks its perimeter in the ElectricalContract
* AlignToReef extra logging
* AlignToReef debugged core motion logic

# Questions/notes for reviewers

# How this was tested
- [ ] tested on robot
- [x] tested in simulator
- [ ] unit tests added

## Video/screenshots (from simulator or live robot)

-----

PR feedback legend

 
| Symbol | Meaning                  |
|--------|--------------------------|
| :star: :star: :star:     | must be addressed                 |
| :star: :star:     | should be addressed        |
| :star:     | something to consider, a good idea                  |
