### PR TITLE
Simulator: more accurate coral scoring/loading

### DIFF
--- a/src/main/java/competition/simulation/MapleSimulator.java
+++ b/src/main/java/competition/simulation/MapleSimulator.java
@@ -144,8 +144,12 @@ public class MapleSimulator implements BaseSimulator {
         var robotNearHumanLoading = false; 
         for (Pose2d station : coralStations) {
             if (currentPose.getTranslation().getDistance(station.getTranslation()) < humanLoadingDistanceThreshold.in(Meters)) {
-                robotNearHumanLoading = true;
-                break;
+                // verify robot angle aligns with the station
+                var angleThresholdDegrees = 10;
+                if(Math.abs(currentPose.getRotation().getDegrees() - station.getRotation().getDegrees()) < angleThresholdDegrees) {
+                    robotNearHumanLoading = true;
+                    break;
+                }
             }
         }
 

--- a/src/main/java/competition/simulation/reef/ReefSimulator.java
+++ b/src/main/java/competition/simulation/reef/ReefSimulator.java
@@ -72,7 +72,7 @@ public class ReefSimulator {
         }
     }
 
-    public void scoreCoralNearestTo(Translation3d scorerPose) {
+    public ReefCoralKey findNearestCoral(Translation3d scorerPose) {
         var coralDistanceMap = new HashMap<ReefCoralKey, Distance>();
         for (ReefFace face : ReefFace.values()) {
             for (ReefLevel level : ReefLevel.values()) {
@@ -91,7 +91,20 @@ public class ReefSimulator {
             .min(Map.Entry.comparingByValue())
             .map(Map.Entry::getKey)
             .orElseThrow(() -> new IllegalStateException("No corals found"));
-        System.out.println("Found closest coral: " + closestCoral);
+        return closestCoral;
+    }
+
+    public void scoreCoral(ReefCoralKey coral) {
+        reefCoralLocations.add(coral);
+    }
+
+    public boolean isCoralScored(ReefCoralKey coral) {
+        return reefCoralLocations.contains(coral);
+    }
+
+    public void scoreCoralNearestTo(Translation3d scorerPose) {
+        var closestCoral = findNearestCoral(scorerPose);
+        
         reefCoralLocations.add(closestCoral);
     }
 
@@ -111,6 +124,10 @@ public class ReefSimulator {
         return reefCoralLocations.stream()
                 .map(coralLocation -> getCoralPose(coralLocation.face(), coralLocation.level(), coralLocation.post()))
                 .toArray(Pose3d[]::new);
+    }
+
+    public Pose3d getCoralPose(ReefCoralKey key) {
+        return getCoralPose(key.face, key.level, key.post);
     }
 
     public Pose3d getCoralPose(ReefFace face, ReefLevel level, ReefPost post) {

--- a/src/main/java/competition/subsystems/elevator/SuperstructureMechanism.java
+++ b/src/main/java/competition/subsystems/elevator/SuperstructureMechanism.java
@@ -46,7 +46,7 @@ public class SuperstructureMechanism {
 
 
     public SuperstructureMechanism() {
-        this.mech2d = new LoggedMechanism2d(1, 2);
+        this.mech2d = new LoggedMechanism2d(1, 3);
 
         // coral system (elevator, arm, scorer)
         var elevatorRoot = mech2d.getRoot("ElevatorRoot", elevatorBasePositionMeters.getX(), elevatorBasePositionMeters.getY());


### PR DESCRIPTION
# Why are we doing this?

To make the simulated environment more realistic, we'll now:
- require that the robot be more lined up with a reef post to score (otherwise it drops to the ground)
- require that there not already be coral on that reef (otherwise it drops to the ground)
- require that the robot be aligned with the human loading station to get fresh coral


# Questions/notes for reviewers

I also have some code locally that map useful operator buttons to the driver gamepad to make solo driving easier, might be nice to include in main for now?

# How this was tested
- [ ] tested on robot
- [ ] tested in simulator
- [ ] unit tests added

## Video/screenshots (from simulator or live robot)

https://github.com/user-attachments/assets/5f4c3463-bdd3-4e6f-bac1-998675899967


-----

PR feedback legend

 
| Symbol | Meaning                  |
|--------|--------------------------|
| :star: :star: :star:     | must be addressed                 |
| :star: :star:     | should be addressed        |
| :star:     | something to consider, a good idea                  |
