### PR TITLE
Oracle: sub state machine class proof of concept

### DIFF
--- a/src/main/java/competition/subsystems/oracle/CollectionStateMachine.java
+++ b/src/main/java/competition/subsystems/oracle/CollectionStateMachine.java
@@ -1,0 +1,68 @@
+package competition.subsystems.oracle;
+
+import java.util.List;
+
+import competition.subsystems.coral_scorer.CoralScorerSubsystem;
+import competition.subsystems.oracle.contracts.CoralCollectionInfoSource;
+import competition.subsystems.pose.Landmarks;
+import competition.subsystems.pose.PoseSubsystem;
+import edu.wpi.first.math.geometry.Pose2d;
+import xbot.common.advantage.AKitLogger;
+import xbot.common.trajectory.XbotSwervePoint;
+
+public class CollectionStateMachine {
+    public enum State {
+        INITIALIZING,
+        WAITING_FOR_CORAL,
+    }
+
+    public enum Result {
+        RUNNING,
+        CORAL_ACQUIRED,
+        FAILURE,
+    }
+
+    PoseSubsystem pose;
+    AKitLogger aKitLog;
+    OracleSubsystem oracle;
+    CoralCollectionInfoSource coralInfoSource;
+    
+    State state = State.INITIALIZING;
+    // Pose2d goalPose;
+
+    public void reset() {
+        state = State.INITIALIZING;
+    }
+
+    public Result run() {
+        switch (state) {
+            case INITIALIZING:
+                // TODO: see if we already have Coral, if so just end the machine now
+                // Command the drive
+                var newDriveAdvice = new OracleDriveAdvice(oracle.getNextInstructionNumber(), getRecommendedCoralPickupTrajectory());
+                // This isn't being used for anything right now for this state machine, commenting it out
+                // goalPose = newDriveAdvice.path().get(newDriveAdvice.path().size() - 1).keyPose;
+                oracle.setCurrentDriveAdvice(newDriveAdvice);
+                // Command the superstructure
+                var newSuperstructureAdvice = new OracleSuperstructureAdvice(
+                        oracle.getNextInstructionNumber(), Landmarks.CoralLevel.COLLECTING, CoralScorerSubsystem.CoralScorerState.INTAKING);
+                oracle.setSuperstructureAdvice(newSuperstructureAdvice);
+                state = State.WAITING_FOR_CORAL;
+                break;
+            case WAITING_FOR_CORAL:
+                if(coralInfoSource.confidentlyHasCoral()) {
+                    return Result.CORAL_ACQUIRED;
+                }
+                break;
+        }   
+        return Result.RUNNING;
+    }
+
+    public List<XbotSwervePoint> getRecommendedCoralPickupTrajectory() {
+        // TODO: go to more than one location.
+        var finalWaypoint = Landmarks.BlueLeftCoralStationMid;
+        var route = oracle.blueReefRoutingCircle.generateSwervePoints(pose.getCurrentPose2d(), finalWaypoint);
+        aKitLog.record("RecommendedRoute", XbotSwervePoint.generateTrajectory(route));
+        return route;
+    }
+}

--- a/src/main/java/competition/subsystems/oracle/OracleSubsystem.java
+++ b/src/main/java/competition/subsystems/oracle/OracleSubsystem.java
@@ -180,8 +180,8 @@ public class OracleSubsystem extends BaseSubsystem {
                 }
 
                 if (coralInfoSource.confidentlyHasScoredCoral()) {
-                    setNextPrimaryActivity(CollectCoral);
                     scoringQueue.advanceToNextScoringGoal();
+                    setPrimaryActivityCollection();
                 }
 
                 break;
@@ -241,6 +241,7 @@ public class OracleSubsystem extends BaseSubsystem {
         // TODO: refactor the common elements out of collecting and scoring
         switch (currentActivity) {
             case CollectCoral:
+
                 var result = collectionStateMachine.run();
                 if(result == CollectionStateMachine.Result.CORAL_ACQUIRED) {
                     setNextPrimaryActivity(ScoreCoral);
@@ -284,7 +285,7 @@ public class OracleSubsystem extends BaseSubsystem {
             default:
                 // How did you get here?
                 // When in doubt, go close to the drivers?
-                currentActivity = CollectCoral;
+                setPrimaryActivityCollection();
                 firstRunInPrimaryActivity = true;
                 break;
         }


### PR DESCRIPTION
This is a hacky proof of concept of trying to encapsulate sub state machines of the oracle. It's not complete/meant to work now, the constructor isn't implemented at all for instance.

The idea is that these sub state machines don't know much about what the parent state machine is doing (the 'primary' state in the current implementation). That way the parent can change things around and hopefully the child can stay untouched. Conversely if the child state machine needs to be improved upon/made more complicated it can do so without the parent code having to change at all.

I also really wanted to have as few boolean flags as possible and instead use state enums to track when things are being initialized. 

I'd also envision splitting up more of what's currently in the OracleSubsystem so that the Primary state machine is 1 thing and then the holder of the all the current state/pointers to things is maybe another class that the sub state machines have access to when they need to set things?

