### PR TITLE
Add a unit test to verify that the robot can start in disabled mode

### DIFF
--- a/src/main/java/competition/Robot.java
+++ b/src/main/java/competition/Robot.java
@@ -24,6 +24,7 @@ public class Robot extends BaseRobot {
 
     final Semaphore reachedDisabledInit = new Semaphore(0);
     final Semaphore reachedDisabledPeriodic = new Semaphore(0);
+    volatile boolean completedFirstDisabledPeriodic = false;
 
     BaseSimulator simulator;
     ElectricalContract simulatorContract = new UnitTestContract2025();
@@ -93,7 +94,9 @@ public class Robot extends BaseRobot {
     @Override
     public void disabledInit() {
         super.disabledInit();
-        reachedDisabledInit.release();
+        if (!completedFirstDisabledPeriodic) {
+            reachedDisabledInit.release();
+        }
     }
 
     @Override
@@ -120,7 +123,10 @@ public class Robot extends BaseRobot {
     @Override
     public void disabledPeriodic() {
         super.disabledPeriodic();
-        reachedDisabledPeriodic.release();
+        if (!completedFirstDisabledPeriodic) {
+            reachedDisabledPeriodic.release();
+            completedFirstDisabledPeriodic = true;
+        }
     }
 
     @Override

--- a/src/main/java/competition/Robot.java
+++ b/src/main/java/competition/Robot.java
@@ -19,8 +19,6 @@ import xbot.common.math.FieldPose;
 import xbot.common.subsystems.pose.BasePoseSubsystem;
 
 import java.util.concurrent.Semaphore;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 
 public class Robot extends BaseRobot {
 

--- a/src/main/java/competition/injection/components/SimulationComponent.java
+++ b/src/main/java/competition/injection/components/SimulationComponent.java
@@ -2,9 +2,11 @@ package competition.injection.components;
 
 import javax.inject.Singleton;
 
+import competition.electrical_contract.ElectricalContract;
 import competition.injection.modules.CommonBinderModule;
 import competition.injection.modules.CommonProviderModule;
 import competition.injection.modules.SimulatedRobotModule;
+import dagger.BindsInstance;
 import dagger.Component;
 import xbot.common.injection.modules.MockDevicesModule;
 import xbot.common.injection.modules.RealControlsModule;
@@ -14,5 +16,10 @@ import xbot.common.injection.modules.SimulationModule;
 @Component(modules = { SimulationModule.class, MockDevicesModule.class, RealControlsModule.class,
         SimulatedRobotModule.class, CommonProviderModule.class, CommonBinderModule.class })
 public abstract class SimulationComponent extends BaseRobotComponent {
-    
+    @Component.Builder
+    public abstract static class Builder {
+        @BindsInstance
+        public abstract Builder electricalContract(ElectricalContract contract);
+        public abstract BaseRobotComponent build();
+    }
 }

--- a/src/main/java/competition/injection/components/SimulationComponent.java
+++ b/src/main/java/competition/injection/components/SimulationComponent.java
@@ -20,6 +20,7 @@ public abstract class SimulationComponent extends BaseRobotComponent {
     public abstract static class Builder {
         @BindsInstance
         public abstract Builder electricalContract(ElectricalContract contract);
+
         public abstract BaseRobotComponent build();
     }
 }

--- a/src/main/java/competition/injection/modules/SimulatedRobotModule.java
+++ b/src/main/java/competition/injection/modules/SimulatedRobotModule.java
@@ -23,10 +23,6 @@ import xbot.common.subsystems.vision.AprilTagVisionSubsystem;
 public abstract class SimulatedRobotModule {
     @Binds
     @Singleton
-    public abstract ElectricalContract getElectricalContract(UnitTestContract2025 impl);
-
-    @Binds
-    @Singleton
     public abstract BaseSimulator getSimulator(MapleSimulator impl);
     
     @Binds

--- a/src/test/java/competition/SimulatedRobotTest.java
+++ b/src/test/java/competition/SimulatedRobotTest.java
@@ -1,9 +1,8 @@
 package competition;
 
-import competition.electrical_contract.ElectricalContract;
 import competition.electrical_contract.UnitTestContract2025;
+import edu.wpi.first.wpilibj.RobotBase;
 import org.junit.Test;
-import xbot.common.command.BaseRobot;
 
 import java.util.concurrent.TimeUnit;
 
@@ -13,24 +12,29 @@ import static org.junit.Assert.fail;
 public class SimulatedRobotTest {
     @Test
     public void testSimulatedRobot() {
+        RobotBase.suppressExitWarning(true);
         try (var robot = new Robot()) {
             robot.simulatorContract = new UnitTestContract2025();
 
-            Thread robotThread = new Thread(() -> {
-                BaseRobot.startRobot(() -> robot);
-            });
+            Thread robotThread = new Thread(robot::startCompetition);
             robotThread.start();
 
             try {
-                var passDisabledInit = robot.reachedDisabledInit.tryAcquire(10, TimeUnit.SECONDS);
+                var passDisabledInit = robot.reachedDisabledInit.tryAcquire(5, TimeUnit.SECONDS);
                 assertTrue("Robot did not reach disabled init", passDisabledInit);
 
-                var passDisabledPeriodic = robot.reachedDisabledPeriodic.tryAcquire(10, TimeUnit.SECONDS);
+                var passDisabledPeriodic = robot.reachedDisabledPeriodic.tryAcquire(5, TimeUnit.SECONDS);
                 assertTrue("Robot did not reach disabled periodic", passDisabledPeriodic);
             } catch (InterruptedException e) {
                 fail("Robot test was interrupted");
             } finally {
                 robot.endCompetition();
+
+                try {
+                    robotThread.join(1000);
+                } catch (InterruptedException e) {
+                    fail("Thread was interrupted");
+                }
             }
         }
     }

--- a/src/test/java/competition/SimulatedRobotTest.java
+++ b/src/test/java/competition/SimulatedRobotTest.java
@@ -11,91 +11,10 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class SimulatedRobotTest {
-    ElectricalContract disabledFeaturesContract = new UnitTestContract2025() {
-        @Override
-        public boolean isDriveReady() {
-            return false;
-        }
-
-        @Override
-        public boolean areCanCodersReady() {
-            return false;
-        }
-
-        @Override
-        public boolean isCoralSensorReady() {
-            return false;
-        }
-
-        @Override
-        public boolean isArmPivotReady() {
-            return false;
-        }
-
-        @Override
-        public boolean isHumanLoadRampReady() {
-            return false;
-        }
-
-        @Override
-        public boolean isAlgaeArmPivotMotorReady() {
-            return false;
-        }
-
-        @Override
-        public boolean isAlgaeCollectionReady() {
-            return false;
-        }
-
-        @Override
-        public boolean isCoralArmPivotAbsoluteEncoderReady() {
-            return false;
-        }
-
-        @Override
-        public boolean isCoralArmPivotLowSensorReady() {
-            return false;
-        }
-
-        @Override
-        public boolean isCoralArmPivotMotorReady() {
-            return false;
-        }
-
-        @Override
-        public boolean isElevatorReady() {
-            return false;
-        }
-    };
-
     @Test
     public void testSimulatedRobot() {
         try (var robot = new Robot()) {
             robot.simulatorContract = new UnitTestContract2025();
-
-            Thread robotThread = new Thread(() -> {
-                BaseRobot.startRobot(() -> robot);
-            });
-            robotThread.start();
-
-            try {
-                var passDisabledInit = robot.reachedDisabledInit.tryAcquire(10, TimeUnit.SECONDS);
-                assertTrue("Robot did not reach disabled init", passDisabledInit);
-
-                var passDisabledPeriodic = robot.reachedDisabledPeriodic.tryAcquire(10, TimeUnit.SECONDS);
-                assertTrue("Robot did not reach disabled periodic", passDisabledPeriodic);
-            } catch (InterruptedException e) {
-                fail("Robot test was interrupted");
-            } finally {
-                robot.endCompetition();
-            }
-        }
-    }
-
-    @Test
-    public void testSimulatedRobotWithDisabledFeatures() {
-        try (var robot = new Robot()) {
-            robot.simulatorContract = disabledFeaturesContract;
 
             Thread robotThread = new Thread(() -> {
                 BaseRobot.startRobot(() -> robot);

--- a/src/test/java/competition/SimulatedRobotTest.java
+++ b/src/test/java/competition/SimulatedRobotTest.java
@@ -1,0 +1,118 @@
+package competition;
+
+import competition.electrical_contract.ElectricalContract;
+import competition.electrical_contract.UnitTestContract2025;
+import org.junit.Test;
+import xbot.common.command.BaseRobot;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class SimulatedRobotTest {
+    ElectricalContract disabledFeaturesContract = new UnitTestContract2025() {
+        @Override
+        public boolean isDriveReady() {
+            return false;
+        }
+
+        @Override
+        public boolean areCanCodersReady() {
+            return false;
+        }
+
+        @Override
+        public boolean isCoralSensorReady() {
+            return false;
+        }
+
+        @Override
+        public boolean isArmPivotReady() {
+            return false;
+        }
+
+        @Override
+        public boolean isHumanLoadRampReady() {
+            return false;
+        }
+
+        @Override
+        public boolean isAlgaeArmPivotMotorReady() {
+            return false;
+        }
+
+        @Override
+        public boolean isAlgaeCollectionReady() {
+            return false;
+        }
+
+        @Override
+        public boolean isCoralArmPivotAbsoluteEncoderReady() {
+            return false;
+        }
+
+        @Override
+        public boolean isCoralArmPivotLowSensorReady() {
+            return false;
+        }
+
+        @Override
+        public boolean isCoralArmPivotMotorReady() {
+            return false;
+        }
+
+        @Override
+        public boolean isElevatorReady() {
+            return false;
+        }
+    };
+
+    @Test
+    public void testSimulatedRobot() {
+        try (var robot = new Robot()) {
+            robot.simulatorContract = new UnitTestContract2025();
+
+            Thread robotThread = new Thread(() -> {
+                BaseRobot.startRobot(() -> robot);
+            });
+            robotThread.start();
+
+            try {
+                var passDisabledInit = robot.reachedDisabledInit.tryAcquire(10, TimeUnit.SECONDS);
+                assertTrue("Robot did not reach disabled init", passDisabledInit);
+
+                var passDisabledPeriodic = robot.reachedDisabledPeriodic.tryAcquire(10, TimeUnit.SECONDS);
+                assertTrue("Robot did not reach disabled periodic", passDisabledPeriodic);
+            } catch (InterruptedException e) {
+                fail("Robot test was interrupted");
+            } finally {
+                robot.endCompetition();
+            }
+        }
+    }
+
+    @Test
+    public void testSimulatedRobotWithDisabledFeatures() {
+        try (var robot = new Robot()) {
+            robot.simulatorContract = disabledFeaturesContract;
+
+            Thread robotThread = new Thread(() -> {
+                BaseRobot.startRobot(() -> robot);
+            });
+            robotThread.start();
+
+            try {
+                var passDisabledInit = robot.reachedDisabledInit.tryAcquire(10, TimeUnit.SECONDS);
+                assertTrue("Robot did not reach disabled init", passDisabledInit);
+
+                var passDisabledPeriodic = robot.reachedDisabledPeriodic.tryAcquire(10, TimeUnit.SECONDS);
+                assertTrue("Robot did not reach disabled periodic", passDisabledPeriodic);
+            } catch (InterruptedException e) {
+                fail("Robot test was interrupted");
+            } finally {
+                robot.endCompetition();
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Why are we doing this?
Our most common programming bug is if the robot code doesn't start for some reason or another.

# Whats changing?
Adds a unti test to start the simulator with some different contract settings to test that the robot starts successfully.

# Questions/notes for reviewers

# How this was tested
- [ ] tested on robot
- [x] tested in simulator
- [x] unit tests added

## Video/screenshots (from simulator or live robot)

-----

PR feedback legend

 
| Symbol | Meaning                  |
|--------|--------------------------|
| :star: :star: :star:     | must be addressed                 |
| :star: :star:     | should be addressed        |
| :star:     | something to consider, a good idea                  |
