### PR TITLE
Ensure that robot completes at least a few cycles of the main loop an…

### DIFF
--- a/src/main/java/competition/Robot.java
+++ b/src/main/java/competition/Robot.java
@@ -19,12 +19,12 @@ import xbot.common.command.XScheduler;
 import xbot.common.math.FieldPose;
 import xbot.common.subsystems.pose.BasePoseSubsystem;
 
-import java.util.concurrent.Semaphore;
+import java.util.concurrent.CountDownLatch;
 
 public class Robot extends BaseRobot {
 
-    final Semaphore reachedDisabledInit = new Semaphore(0);
-    final Semaphore reachedEndOfLoop = new Semaphore(-5);
+    final CountDownLatch reachedDisabledInit = new CountDownLatch(1);
+    final CountDownLatch reachedEndOfLoop = new CountDownLatch(5);
 
     BaseSimulator simulator;
     ElectricalContract simulatorContract = new UnitTestContract2025();
@@ -95,7 +95,7 @@ public class Robot extends BaseRobot {
     @Override
     public void disabledInit() {
         super.disabledInit();
-        reachedDisabledInit.release();
+        reachedDisabledInit.countDown();
     }
 
     @Override
@@ -131,7 +131,7 @@ public class Robot extends BaseRobot {
     @Override
     protected void loopFunc() {
         super.loopFunc();
-        reachedEndOfLoop.release();
+        reachedEndOfLoop.countDown();
     }
 
     public XScheduler getScheduler() {

--- a/src/main/java/competition/Robot.java
+++ b/src/main/java/competition/Robot.java
@@ -15,6 +15,7 @@ import competition.subsystems.drive.DriveSubsystem;
 import competition.subsystems.pose.PoseSubsystem;
 import edu.wpi.first.wpilibj.Preferences;
 import xbot.common.command.BaseRobot;
+import xbot.common.command.XScheduler;
 import xbot.common.math.FieldPose;
 import xbot.common.subsystems.pose.BasePoseSubsystem;
 
@@ -23,8 +24,7 @@ import java.util.concurrent.Semaphore;
 public class Robot extends BaseRobot {
 
     final Semaphore reachedDisabledInit = new Semaphore(0);
-    final Semaphore reachedDisabledPeriodic = new Semaphore(0);
-    volatile boolean completedFirstDisabledPeriodic = false;
+    final Semaphore reachedEndOfLoop = new Semaphore(-5);
 
     BaseSimulator simulator;
     ElectricalContract simulatorContract = new UnitTestContract2025();
@@ -95,9 +95,7 @@ public class Robot extends BaseRobot {
     @Override
     public void disabledInit() {
         super.disabledInit();
-        if (!completedFirstDisabledPeriodic) {
-            reachedDisabledInit.release();
-        }
+        reachedDisabledInit.release();
     }
 
     @Override
@@ -122,20 +120,23 @@ public class Robot extends BaseRobot {
     }
 
     @Override
-    public void disabledPeriodic() {
-        super.disabledPeriodic();
-        if (!completedFirstDisabledPeriodic) {
-            reachedDisabledPeriodic.release();
-            completedFirstDisabledPeriodic = true;
-        }
-    }
-
-    @Override
     public void simulationPeriodic() {
         super.simulationPeriodic();
 
         if (simulator != null) {
             simulator.update();
         }
+    }
+
+    @Override
+    protected void loopFunc() {
+        super.loopFunc();
+
+        System.out.println("Run loopFunc");
+        reachedEndOfLoop.release();
+    }
+
+    public XScheduler getScheduler() {
+        return xScheduler;
     }
 }

--- a/src/main/java/competition/Robot.java
+++ b/src/main/java/competition/Robot.java
@@ -131,8 +131,6 @@ public class Robot extends BaseRobot {
     @Override
     protected void loopFunc() {
         super.loopFunc();
-
-        System.out.println("Run loopFunc");
         reachedEndOfLoop.release();
     }
 

--- a/src/main/java/competition/subsystems/elevator/ElevatorSubsystem.java
+++ b/src/main/java/competition/subsystems/elevator/ElevatorSubsystem.java
@@ -232,7 +232,6 @@ public class ElevatorSubsystem extends BaseSetpointSubsystem<Distance> {
 
     private Distance getRawDistance() {
         if (contract.isElevatorDistanceSensorReady()) {
-            System.out.println(distanceSensor.getClass().getName());
             return distanceSensor.getDistance();
         } else {
             return Meter.of(0);

--- a/src/main/java/competition/subsystems/elevator/ElevatorSubsystem.java
+++ b/src/main/java/competition/subsystems/elevator/ElevatorSubsystem.java
@@ -232,6 +232,7 @@ public class ElevatorSubsystem extends BaseSetpointSubsystem<Distance> {
 
     private Distance getRawDistance() {
         if (contract.isElevatorDistanceSensorReady()) {
+            System.out.println(distanceSensor.getClass().getName());
             return distanceSensor.getDistance();
         } else {
             return Meter.of(0);

--- a/src/test/java/competition/SimulatedRobotTest.java
+++ b/src/test/java/competition/SimulatedRobotTest.java
@@ -21,11 +21,11 @@ public class SimulatedRobotTest {
             robotThread.start();
 
             try {
-                var passDisabledInit = robot.reachedDisabledInit.tryAcquire(5, TimeUnit.SECONDS);
+                var passDisabledInit = robot.reachedDisabledInit.await(5, TimeUnit.SECONDS);
                 assertTrue("Robot did not reach disabled init", passDisabledInit);
 
-                var passDisabledPeriodic = robot.reachedEndOfLoop.tryAcquire(5, TimeUnit.SECONDS);
-                assertTrue("Robot did not reach disabled periodic", passDisabledPeriodic);
+                var passExecutionLoops = robot.reachedEndOfLoop.await(5, TimeUnit.SECONDS);
+                assertTrue("Robot did not complete enough execution loops", passExecutionLoops);
 
                 assertEquals(0, robot.getScheduler().getNumberOfCrashes());
             } catch (InterruptedException e) {

--- a/src/test/java/competition/SimulatedRobotTest.java
+++ b/src/test/java/competition/SimulatedRobotTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -23,8 +24,10 @@ public class SimulatedRobotTest {
                 var passDisabledInit = robot.reachedDisabledInit.tryAcquire(5, TimeUnit.SECONDS);
                 assertTrue("Robot did not reach disabled init", passDisabledInit);
 
-                var passDisabledPeriodic = robot.reachedDisabledPeriodic.tryAcquire(5, TimeUnit.SECONDS);
+                var passDisabledPeriodic = robot.reachedEndOfLoop.tryAcquire(5, TimeUnit.SECONDS);
                 assertTrue("Robot did not reach disabled periodic", passDisabledPeriodic);
+
+                assertEquals(0, robot.getScheduler().getNumberOfCrashes());
             } catch (InterruptedException e) {
                 fail("Robot test was interrupted");
             } finally {


### PR DESCRIPTION
…d it does not crash in test

# Why are we doing this?
We need to be able to check if XScheduler handled any unexpected failures for the robot startup test to be valuable.

# Whats changing?
Ensure that a few robot cycles are able to run before the test completes. Ensure that the scheduler reported no crashes.

# Questions/notes for reviewers

# How this was tested
- [ ] tested on robot
- [ ] tested in simulator
- [x] unit tests added

## Video/screenshots (from simulator or live robot)

-----

PR feedback legend

 
| Symbol | Meaning                  |
|--------|--------------------------|
| :star: :star: :star:     | must be addressed                 |
| :star: :star:     | should be addressed        |
| :star:     | something to consider, a good idea                  |
