### PR TITLE
Add a unit test with the drive marked as not ready

### DIFF
--- a/src/main/java/competition/injection/components/CompetitionTestComponent.java
+++ b/src/main/java/competition/injection/components/CompetitionTestComponent.java
@@ -2,9 +2,11 @@ package competition.injection.components;
 
 import javax.inject.Singleton;
 
+import competition.electrical_contract.ElectricalContract;
 import competition.injection.modules.CommonBinderModule;
 import competition.injection.modules.CommonProviderModule;
 import competition.injection.modules.UnitTestRobotModule;
+import dagger.BindsInstance;
 import dagger.Component;
 import xbot.common.injection.modules.MockControlsModule;
 import xbot.common.injection.modules.MockDevicesModule;
@@ -14,5 +16,11 @@ import xbot.common.injection.modules.UnitTestModule;
 @Component(modules = { UnitTestModule.class, MockDevicesModule.class, MockControlsModule.class,
         CommonProviderModule.class, CommonBinderModule.class, UnitTestRobotModule.class})
 public abstract class CompetitionTestComponent extends BaseRobotComponent {
-    
+    @Component.Builder
+    public abstract static class Builder {
+        @BindsInstance
+        public abstract CompetitionTestComponent.Builder electricalContract(ElectricalContract contract);
+
+        public abstract BaseRobotComponent build();
+    }
 }

--- a/src/main/java/competition/injection/modules/UnitTestRobotModule.java
+++ b/src/main/java/competition/injection/modules/UnitTestRobotModule.java
@@ -22,9 +22,5 @@ import javax.inject.Singleton;
 public abstract class UnitTestRobotModule {
     @Binds
     @Singleton
-    public abstract ElectricalContract getElectricalContract(UnitTestContract2025 impl);
-
-    @Binds
-    @Singleton
     public abstract BaseSimulator getSimulator(MapleSimulator impl);
 }

--- a/src/test/java/competition/BaseCompetitionTest.java
+++ b/src/test/java/competition/BaseCompetitionTest.java
@@ -1,5 +1,6 @@
 package competition;
 
+import competition.electrical_contract.UnitTestContract2025;
 import competition.injection.components.CompetitionTestComponent;
 import competition.injection.components.DaggerCompetitionTestComponent;
 import xbot.common.injection.BaseWPITest;
@@ -7,7 +8,10 @@ import xbot.common.injection.BaseWPITest;
 public class BaseCompetitionTest extends BaseWPITest{
     @Override
     protected CompetitionTestComponent createDaggerComponent() {
-        return DaggerCompetitionTestComponent.create();
+        return (CompetitionTestComponent)DaggerCompetitionTestComponent
+                .builder()
+                .electricalContract(new UnitTestContract2025())
+                .build();
     }
 
     @Override

--- a/src/test/java/competition/subsystems/drive/DriveSubsystemDisabledTest.java
+++ b/src/test/java/competition/subsystems/drive/DriveSubsystemDisabledTest.java
@@ -1,0 +1,50 @@
+package competition.subsystems.drive;
+
+import competition.BaseCompetitionTest;
+import competition.electrical_contract.UnitTestContract2025;
+import competition.injection.components.CompetitionTestComponent;
+import competition.injection.components.DaggerCompetitionTestComponent;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class DriveSubsystemDisabledTest extends BaseCompetitionTest {
+    @Override
+    protected CompetitionTestComponent createDaggerComponent() {
+        return (CompetitionTestComponent) DaggerCompetitionTestComponent
+                .builder()
+                .electricalContract(new UnitTestContract2025() {
+                    @Override
+                    public boolean isDriveReady() {
+                        return false;
+                    }
+
+                    @Override
+                    public boolean areCanCodersReady() {
+                        return false;
+                    }
+                })
+                .build();
+    }
+
+    @Test
+    public void testDriveSubsystemWithDriveDisabled() {
+        DriveSubsystem driveSubsystem = (DriveSubsystem)getInjectorComponent().driveSubsystem();
+        assertNotNull(driveSubsystem);
+
+        driveSubsystem.refreshDataFrame();
+        driveSubsystem.periodic();
+
+        var moduleStates = driveSubsystem.getSwerveModuleStates();
+        assertEquals(4, moduleStates.length);
+
+        for (var moduleState : moduleStates) {
+            assertEquals(0, moduleState.speedMetersPerSecond, 0.001);
+            assertEquals(0, moduleState.angle.getDegrees(), 0.001);
+        }
+
+        assertNull(driveSubsystem.getFrontLeftSwerveModuleSubsystem().getDriveSubsystem().getMotorController());
+    }
+}

--- a/src/test/java/competition/subsystems/drive/DriveSubsystemTest.java
+++ b/src/test/java/competition/subsystems/drive/DriveSubsystemTest.java
@@ -1,7 +1,7 @@
 package competition.subsystems.drive;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 
 import org.junit.Test;
 
@@ -11,6 +11,19 @@ public class DriveSubsystemTest extends BaseCompetitionTest {
     @Test
     public void testDriveSubsystem() {
         DriveSubsystem driveSubsystem = (DriveSubsystem)getInjectorComponent().driveSubsystem();
-        assertNotEquals(driveSubsystem, null);
+        assertNotNull(driveSubsystem);
+
+        driveSubsystem.refreshDataFrame();
+        driveSubsystem.periodic();
+
+        var moduleStates = driveSubsystem.getSwerveModuleStates();
+        assertEquals(4, moduleStates.length);
+
+        for (var moduleState : moduleStates) {
+            assertEquals(0, moduleState.speedMetersPerSecond, 0.001);
+            assertEquals(0, moduleState.angle.getDegrees(), 0.001);
+        }
+
+        assertNotNull(driveSubsystem.getFrontLeftSwerveModuleSubsystem().getDriveSubsystem().getMotorController());
     }
 }


### PR DESCRIPTION
# Why are we doing this?
Bugs related to electrical contract isReady flags are one of the most common sources of robot code bugs.

# Whats changing?
Add a sample unit test that makes sure a subsystem doesn't crash even when its components are not ready yet.

# Questions/notes for reviewers

# How this was tested
- [ ] tested on robot
- [ ] tested in simulator
- [x] unit tests added

## Video/screenshots (from simulator or live robot)

-----

PR feedback legend

 
| Symbol | Meaning                  |
|--------|--------------------------|
| :star: :star: :star:     | must be addressed                 |
| :star: :star:     | should be addressed        |
| :star:     | something to consider, a good idea                  |
