### PR TITLE
Add missing guards in elevator code

### DIFF
--- a/src/main/java/competition/subsystems/elevator/ElevatorSubsystem.java
+++ b/src/main/java/competition/subsystems/elevator/ElevatorSubsystem.java
@@ -171,7 +171,11 @@ public class ElevatorSubsystem extends BaseSetpointSubsystem<Distance> {
 
     public void markElevatorAsCalibratedAgainstLowerLimit(){
         isCalibrated = true;
-        elevatorPositionOffset = this.masterMotor.getPosition().in(Rotations);
+        if (this.masterMotor != null) {
+            elevatorPositionOffset = this.masterMotor.getPosition().in(Rotations);
+        } else {
+            elevatorPositionOffset = 0;
+        }
     }
 
     @Override
@@ -185,7 +189,11 @@ public class ElevatorSubsystem extends BaseSetpointSubsystem<Distance> {
     }
 
     public LinearVelocity getCurrentVelocity() {
-        return MetersPerSecond.of(masterMotor.getVelocity().in(RotationsPerSecond) * metersPerRotation.in(Meters));
+        if (masterMotor != null) {
+            return MetersPerSecond.of(masterMotor.getVelocity().in(RotationsPerSecond) * metersPerRotation.in(Meters));
+        } else {
+            return MetersPerSecond.of(0);
+        }
     }
 
     @Override

--- a/src/test/java/competition/subsystems/elevator/ElevatorSubsystemDisabledTest.java
+++ b/src/test/java/competition/subsystems/elevator/ElevatorSubsystemDisabledTest.java
@@ -1,0 +1,57 @@
+package competition.subsystems.elevator;
+
+import competition.BaseCompetitionTest;
+import competition.electrical_contract.UnitTestContract2025;
+import competition.injection.components.CompetitionTestComponent;
+import competition.injection.components.DaggerCompetitionTestComponent;
+import org.junit.Test;
+
+import static edu.wpi.first.units.Units.Meters;
+import static edu.wpi.first.units.Units.MetersPerSecond;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class ElevatorSubsystemDisabledTest extends BaseCompetitionTest {
+    @Override
+    protected CompetitionTestComponent createDaggerComponent() {
+        return (CompetitionTestComponent) DaggerCompetitionTestComponent
+                .builder()
+                .electricalContract(new UnitTestContract2025() {
+                    @Override
+                    public boolean isElevatorReady() {
+                        return false;
+                    }
+
+                    @Override
+                    public boolean isElevatorBottomSensorReady() {
+                        return false;
+                    }
+
+                    @Override
+                    public boolean isElevatorDistanceSensorReady() {
+                        return false;
+                    }
+                })
+                .build();
+    }
+
+    @Test
+    public void testElevatorSubsystem() {
+        var subsystem = getInjectorComponent().elevatorSubsystem();
+        assertNotNull(subsystem);
+
+        subsystem.refreshDataFrame();
+        subsystem.periodic();
+
+        assertNull(subsystem.masterMotor);
+
+        assertTrue(Meters.of(0).isNear(subsystem.getCurrentValue(), 0.001));
+        assertTrue(MetersPerSecond.of(0).isNear(subsystem.getCurrentVelocity(), 0.001));
+
+        assertFalse(subsystem.isTouchingBottom());
+
+        subsystem.markElevatorAsCalibratedAgainstLowerLimit();
+    }
+}


### PR DESCRIPTION
# Why are we doing this?
We need to guard against missing elevator components so that robots don't crash.

# Whats changing?
Add guards and a test for breaking the guards

# Questions/notes for reviewers

# How this was tested
- [ ] tested on robot
- [ ] tested in simulator
- [x] unit tests added

## Video/screenshots (from simulator or live robot)

-----

PR feedback legend

 
| Symbol | Meaning                  |
|--------|--------------------------|
| :star: :star: :star:     | must be addressed                 |
| :star: :star:     | should be addressed        |
| :star:     | something to consider, a good idea                  |
