### PR TITLE
Dont allow calibration without sensor

### DIFF
--- a/src/main/java/competition/subsystems/elevator/commands/ElevatorMaintainerCommand.java
+++ b/src/main/java/competition/subsystems/elevator/commands/ElevatorMaintainerCommand.java
@@ -97,23 +97,21 @@ public class ElevatorMaintainerCommand extends BaseMaintainerCommand<Distance> {
                 XCANMotorController.MotorPidMode.Voltage);
     }
 
+    //defaults humanControlAction if there is no bottom sensor
     @Override
     protected void uncalibratedMachineControlAction() {
-        var mode = calibrationDecider.decideMode(elevator.isCalibrated());
-
-        if(!contract.isElevatorBottomSensorReady()){
-            mode = CalibrationDecider.CalibrationMode.GaveUp;
-        }
+        var mode = contract.isElevatorBottomSensorReady() ?
+                calibrationDecider.decideMode(elevator.isCalibrated()) : CalibrationDecider.CalibrationMode.GaveUp;
 
         switch (mode){
             case Calibrated -> calibratedMachineControlAction();
-            case Attempting -> attemptCalibrationIfSensorExists();
+            case Attempting -> attemptCalibration();
             case GaveUp -> humanControlAction();
             default -> humanControlAction();
         }
     }
 
-    private void attemptCalibrationIfSensorExists(){
+    private void attemptCalibration(){
         elevator.setPower(elevator.calibrationNegativePower.get());
 
         if (elevator.isTouchingBottom()){

--- a/src/main/java/competition/subsystems/elevator/commands/ElevatorMaintainerCommand.java
+++ b/src/main/java/competition/subsystems/elevator/commands/ElevatorMaintainerCommand.java
@@ -101,6 +101,10 @@ public class ElevatorMaintainerCommand extends BaseMaintainerCommand<Distance> {
     protected void uncalibratedMachineControlAction() {
         var mode = calibrationDecider.decideMode(elevator.isCalibrated());
 
+        if(!contract.isElevatorBottomSensorReady()){
+            mode = CalibrationDecider.CalibrationMode.GaveUp;
+        }
+
         switch (mode){
             case Calibrated -> calibratedMachineControlAction();
             case Attempting -> attemptCalibrationIfSensorExists();
@@ -110,9 +114,6 @@ public class ElevatorMaintainerCommand extends BaseMaintainerCommand<Distance> {
     }
 
     private void attemptCalibrationIfSensorExists(){
-        if(!contract.isElevatorBottomSensorReady()){
-            return;
-        }
         elevator.setPower(elevator.calibrationNegativePower.get());
 
         if (elevator.isTouchingBottom()){

--- a/src/main/java/competition/subsystems/elevator/commands/ElevatorMaintainerCommand.java
+++ b/src/main/java/competition/subsystems/elevator/commands/ElevatorMaintainerCommand.java
@@ -100,7 +100,8 @@ public class ElevatorMaintainerCommand extends BaseMaintainerCommand<Distance> {
     //defaults humanControlAction if there is no bottom sensor
     @Override
     protected void uncalibratedMachineControlAction() {
-        var mode = contract.isElevatorBottomSensorReady() ?
+        var mode = contract.isElevatorBottomSensorReady()
+                ?
                 calibrationDecider.decideMode(elevator.isCalibrated()) : CalibrationDecider.CalibrationMode.GaveUp;
 
         switch (mode){

--- a/src/main/java/competition/subsystems/elevator/commands/ElevatorMaintainerCommand.java
+++ b/src/main/java/competition/subsystems/elevator/commands/ElevatorMaintainerCommand.java
@@ -101,8 +101,8 @@ public class ElevatorMaintainerCommand extends BaseMaintainerCommand<Distance> {
     @Override
     protected void uncalibratedMachineControlAction() {
         var mode = contract.isElevatorBottomSensorReady()
-                ?
-                calibrationDecider.decideMode(elevator.isCalibrated()) : CalibrationDecider.CalibrationMode.GaveUp;
+                ? calibrationDecider.decideMode(elevator.isCalibrated())
+                : CalibrationDecider.CalibrationMode.GaveUp;
 
         switch (mode){
             case Calibrated -> calibratedMachineControlAction();


### PR DESCRIPTION
# Why are we doing this?
Theres no sensor on the robot right now, so it continuously applies downforce to try and calibrate even when its at the bottom, this is to prevent that for testing pursposes.
Asana task URL:

# Whats changing?

# Questions/notes for reviewers

# How this was tested
- [ ] tested on robot
- [x ] tested in simulator
- [ ] unit tests added

## Video/screenshots (from simulator or live robot)

-----

PR feedback legend

 
| Symbol | Meaning                  |
|--------|--------------------------|
| :star: :star: :star:     | must be addressed                 |
| :star: :star:     | should be addressed        |
| :star:     | something to consider, a good idea                  |
