### PR TITLE
CoralArmSim: Fix for changes made for real robot

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,7 +111,7 @@ dependencies {
     testImplementation "org.mockito:mockito-core:3.+"
 
     // xtables
-    implementation "org.kobe.xbot:xtables:5.1.7"
+    implementation "org.kobe.xbot:xtables:5.2.6"
 
     def akitJson = new groovy.json.JsonSlurper().parseText(new File(projectDir.getAbsolutePath() + "/vendordeps/AdvantageKit.json").text)
     annotationProcessor "org.littletonrobotics.akit:akit-autolog:$akitJson.version"

--- a/src/main/java/competition/simulation/coral_arm/CoralArmSimConstants.java
+++ b/src/main/java/competition/simulation/coral_arm/CoralArmSimConstants.java
@@ -16,7 +16,8 @@ public class CoralArmSimConstants {
     // the frame of reference for these angles is 0' right, 90' up, 180' left, 270' down
     // so we have 225 as the starting angle which is 0' in arm relative terms
     public static final Angle minAngleRads = Degrees.of(225 - 125);
-    public static final Angle maxAngleRads = Degrees.of(225);
+    public static final Angle armEncoderAnglePerRotation = Degrees.of(6.94444);
+    // right now the arm starts past it's 0' point because of gravity so pick that as the 'max' angle here (which is our min)
+    public static final Angle maxAngleRads = Degrees.of(225 + armEncoderAnglePerRotation.times(5).in(Degrees));
     public static final Angle startingAngle = maxAngleRads;
-    public static final Angle armEncoderAnglePerRotation = Degrees.of(0.1);
 }

--- a/src/main/java/competition/simulation/coral_arm/CoralArmSimConstants.java
+++ b/src/main/java/competition/simulation/coral_arm/CoralArmSimConstants.java
@@ -17,6 +17,7 @@ public class CoralArmSimConstants {
     // so we have 225 as the starting angle which is 0' in arm relative terms
     public static final Angle minAngleRads = Degrees.of(225 - 125);
     public static final Angle armEncoderAnglePerRotation = Degrees.of(6.94444);
+    public static final Angle angleAtRobotZero = Degrees.of(225);
     // right now the arm starts past it's 0' point because of gravity so pick that as the 'max' angle here (which is our min)
     public static final Angle maxAngleRads = Degrees.of(225 + armEncoderAnglePerRotation.times(5).in(Degrees));
     public static final Angle startingAngle = maxAngleRads;

--- a/src/main/java/competition/simulation/coral_arm/CoralArmSimulator.java
+++ b/src/main/java/competition/simulation/coral_arm/CoralArmSimulator.java
@@ -18,6 +18,7 @@ import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.MockDigitalInput;
 import edu.wpi.first.wpilibj.RobotController;
 import edu.wpi.first.wpilibj.simulation.SingleJointedArmSim;
+import xbot.common.advantage.AKitLogger;
 import xbot.common.controls.actuators.mock_adapters.MockCANMotorController;
 import xbot.common.controls.sensors.mock_adapters.MockAbsoluteEncoder;
 import xbot.common.math.PIDManager;
@@ -27,6 +28,7 @@ public class CoralArmSimulator {
     final DCMotor motor = DCMotor.getKrakenX60(1);
     final SingleJointedArmSim armSim;
     final PIDManager pidManager;
+    final AKitLogger aKitLog;
 
     final CoralArmSubsystem armPivotSubsystem;
     final MockCANMotorController armMotor;
@@ -36,6 +38,7 @@ public class CoralArmSimulator {
     @Inject
     public CoralArmSimulator(CoralArmSubsystem armPivotSubsystem, PIDManager.PIDManagerFactory pidManagerFactory, PropertyFactory pf) {
         pf.setPrefix("CoralArmSimulator");
+        this.aKitLog = new AKitLogger("FieldSimulation/CoralArm");
         this.pidManager = pidManagerFactory.create(pf.getPrefix() + "/CANMotorPositionalPID", 0.01, 0.001, 0.0, 0.0, 1.0, -1.0);
         this.armPivotSubsystem = armPivotSubsystem;
         this.armMotor = (MockCANMotorController) armPivotSubsystem.armMotor;
@@ -68,6 +71,7 @@ public class CoralArmSimulator {
 
         // Read out the new arm position for rendering
         var armRelativeAngle = getArmAngle();
+        aKitLog.record("armAngle", armRelativeAngle.in(Degrees));
 
         var armMotorRotations = armRelativeAngle.in(Radians) / CoralArmSimConstants.armEncoderAnglePerRotation.in(Radians);
         armMotor.setPosition(Rotations.of(armMotorRotations));
@@ -84,7 +88,7 @@ public class CoralArmSimulator {
         // reference where the bottom is 0' and the top is 125'
         var armSimAngle = Radians.of(armSim.getAngleRads());
 
-        return armSimAngle.minus(CoralArmSimConstants.maxAngleRads).times(-1);
+        return armSimAngle.minus(CoralArmSimConstants.angleAtRobotZero).times(-1);
     }
 
     public boolean isAtCollectionAngle() {

--- a/src/main/java/competition/subsystems/coral_arm/CoralArmSubsystem.java
+++ b/src/main/java/competition/subsystems/coral_arm/CoralArmSubsystem.java
@@ -85,7 +85,7 @@ public class CoralArmSubsystem extends BaseSetpointSubsystem<Angle> {
             this.lowSensor = null;
         }
 
-        this.degreesPerRotations = propertyFactory.createPersistentProperty("Degrees Per Rotations", 0.1);
+        this.degreesPerRotations = propertyFactory.createPersistentProperty("Degrees Per Rotations", 6.94444);
 
         this.rangeOfMotionDegrees = propertyFactory.createPersistentProperty("Range of Motion in Degrees", 125);
         this.minArmPosition = propertyFactory.createPersistentProperty("Min AbsEncoder Position in Degrees", 90);


### PR DESCRIPTION
# Why are we doing this?

John hacked away the coral arm working in angles and instead it works in rotations right now. This totally borked the sim logic. This PR makes the arm work in the sim (though the robots sense of where the arm is is still kinda messed up).

Asana task URL:

# Whats changing?

# Questions/notes for reviewers

# How this was tested
- [ ] tested on robot
- [x] tested in simulator
- [ ] unit tests added

## Video/screenshots (from simulator or live robot)

-----

PR feedback legend

 
| Symbol | Meaning                  |
|--------|--------------------------|
| :star: :star: :star:     | must be addressed                 |
| :star: :star:     | should be addressed        |
| :star:     | something to consider, a good idea                  |
