### PR TITLE
revert change to have robot coral arm start lower than collection point

### DIFF
--- a/src/main/java/competition/simulation/coral_arm/CoralArmSimConstants.java
+++ b/src/main/java/competition/simulation/coral_arm/CoralArmSimConstants.java
@@ -18,7 +18,6 @@ public class CoralArmSimConstants {
     public static final Angle minAngleRads = Degrees.of(225 - 125);
     public static final Angle armEncoderAnglePerRotation = Degrees.of(6.94444);
     public static final Angle angleAtRobotZero = Degrees.of(225);
-    // right now the arm starts past it's 0' point because of gravity so pick that as the 'max' angle here (which is our min)
-    public static final Angle maxAngleRads = Degrees.of(225 + armEncoderAnglePerRotation.times(5).in(Degrees));
+    public static final Angle maxAngleRads = Degrees.of(225);
     public static final Angle startingAngle = maxAngleRads;
 }


### PR DESCRIPTION


# Why are we doing this?

This was added to simulate how the arm was hanging under the collection point, but now there's a hardstop on the robot so that behavior has gone away and we can go back to calibration at the start position as 0

Asana task URL:

# Whats changing?

# Questions/notes for reviewers

# How this was tested
- [ ] tested on robot
- [ ] tested in simulator
- [ ] unit tests added

## Video/screenshots (from simulator or live robot)

-----

PR feedback legend

 
| Symbol | Meaning                  |
|--------|--------------------------|
| :star: :star: :star:     | must be addressed                 |
| :star: :star:     | should be addressed        |
| :star:     | something to consider, a good idea                  |
