### PR TITLE
Adding a drive to coral station via vision avoidance system.

### DIFF
--- a/src/main/java/competition/operator_interface/OperatorCommandMap.java
+++ b/src/main/java/competition/operator_interface/OperatorCommandMap.java
@@ -18,7 +18,7 @@ import competition.subsystems.coral_scorer.commands.StopCoralCommand;
 import competition.subsystems.drive.DriveSubsystem;
 import competition.subsystems.drive.commands.AlignToReefWithAprilTagCommand;
 import competition.subsystems.drive.commands.DebugSwerveModuleCommand;
-import competition.subsystems.drive.commands.DriveToWaypointsWithVisionCommand;
+import competition.subsystems.drive.commands.DriveToCoralStationWithVisionCommand;
 import competition.subsystems.drive.commands.SwerveDriveWithJoysticksCommand;
 import competition.subsystems.drive.commands.TeleportToPositionCommand;
 import competition.subsystems.elevator.ElevatorSubsystem;
@@ -53,7 +53,7 @@ public class OperatorCommandMap {
             Provider<AlignToReefWithAprilTagCommand> alignToReefWithAprilTagProvider,
             DriveAccordingToOracleCommand driveAccordingToOracle,
             SuperstructureAccordingToOracleCommand superstructureAccordingToOracle,
-            DriveToWaypointsWithVisionCommand driveToWaypointsWithVisionCommand,
+            DriveToCoralStationWithVisionCommand driveToCoralStationWithVisionCommand,
             TeleportToPositionCommand teleportToPositionCommand,
             PrepCoralSystemCommandGroupFactory prepCoralSystemCommandGroupFactory,
             IntakeCoralCommand intakeCoralCommand,
@@ -85,6 +85,7 @@ public class OperatorCommandMap {
         operatorInterface.driverGamepad.getifAvailable(XXboxController.XboxButton.Y).onTrue(prepL4);
         var homed = prepCoralSystemCommandGroupFactory.create(Landmarks.CoralLevel.COLLECTING);
         operatorInterface.driverGamepad.getifAvailable(XXboxController.XboxButton.B).onTrue(homed);
+        operatorInterface.driverGamepad.getifAvailable(XXboxController.XboxButton.X).onTrue(driveToCoralStationWithVisionCommand);
 
         operatorInterface.driverGamepad.getPovIfAvailable(0).onTrue(debugModule);
         operatorInterface.driverGamepad.getPovIfAvailable(90).onTrue(changeActiveModule);

--- a/src/main/java/competition/subsystems/drive/commands/DriveToCoralStationWithVisionCommand.java
+++ b/src/main/java/competition/subsystems/drive/commands/DriveToCoralStationWithVisionCommand.java
@@ -31,6 +31,8 @@ public class DriveToCoralStationWithVisionCommand extends DriveToWaypointsWithVi
     @Override
     public void initialize() {
         var radiusOfRobot = Math.sqrt(Math.pow(this.distanceToOuterBumerInMeters, 2.0) * 2.0);
+        // TODO: Add additional logic after next test to swithc to deciding based on DriverStation
+        // and which coral station is clossest.
         var coralStationPose = Landmarks.getCoralStationSectionPose(Landmarks.CoralStation.LEFT,
                 Landmarks.CoralStationSection.MID);
         var deltaTranslation = new Translation2d(radiusOfRobot, coralStationPose.getRotation());

--- a/src/main/java/competition/subsystems/drive/commands/DriveToCoralStationWithVisionCommand.java
+++ b/src/main/java/competition/subsystems/drive/commands/DriveToCoralStationWithVisionCommand.java
@@ -1,0 +1,44 @@
+package competition.subsystems.drive.commands;
+
+import competition.electrical_contract.ElectricalContract;
+import competition.subsystems.drive.DriveSubsystem;
+import competition.subsystems.pose.Landmarks;
+import competition.subsystems.pose.PoseSubsystem;
+import competition.subsystems.vision.CoprocessorCommunicationSubsystem;
+import competition.subsystems.drive.commands.DriveToWaypointsWithVisionCommand;
+import edu.wpi.first.units.Units;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Transform2d;
+import edu.wpi.first.math.geometry.Translation2d;
+import xbot.common.logging.RobotAssertionManager;
+import xbot.common.properties.PropertyFactory;
+import xbot.common.subsystems.drive.control_logic.HeadingModule;
+
+import javax.inject.Inject;
+
+public class DriveToCoralStationWithVisionCommand extends DriveToWaypointsWithVisionCommand {
+    Pose2d targetCoralStationSection;
+    double distanceToOuterBumerInMeters;
+
+    @Inject
+    DriveToCoralStationWithVisionCommand(PoseSubsystem pose, DriveSubsystem drive, CoprocessorCommunicationSubsystem coprocessorComms,
+                                         PropertyFactory pf, HeadingModule.HeadingModuleFactory headingModuleFactory,
+                                         RobotAssertionManager assertionManager, ElectricalContract electricalContract) {
+        super(pose, drive, coprocessorComms, pf, headingModuleFactory, assertionManager);
+        this.distanceToOuterBumerInMeters = electricalContract.getDistanceFromCenterToOuterBumperX().in(Units.Meters);
+    }
+
+    @Override
+    public void initialize() {
+        var radiusOfRobot = Math.sqrt(Math.pow(this.distanceToOuterBumerInMeters, 2.0) * 2.0);
+        var coralStationPose = Landmarks.getCoralStationSectionPose(Landmarks.CoralStation.LEFT,
+                Landmarks.CoralStationSection.MID);
+        var deltaTranslation = new Translation2d(radiusOfRobot, coralStationPose.getRotation());
+        var destinationTranslation = coralStationPose.getTranslation().plus(deltaTranslation);
+        var destinationPose = new Pose2d(destinationTranslation, coralStationPose.getRotation());
+
+        if (setTargetPoseForVision(destinationPose)) {
+            super.initialize();
+        }
+    }
+}

--- a/src/main/java/competition/subsystems/vision/CoprocessorCommunicationSubsystem.java
+++ b/src/main/java/competition/subsystems/vision/CoprocessorCommunicationSubsystem.java
@@ -23,6 +23,7 @@ public class CoprocessorCommunicationSubsystem extends BaseSubsystem implements 
     final RobotAssertionManager assertionManager;
 
     // xtables properties
+    final StringProperty xtablesTargetPose;
     final StringProperty xtablesCoordinateLocation;
     final StringProperty xtablesHeadingLocation;
 
@@ -35,6 +36,7 @@ public class CoprocessorCommunicationSubsystem extends BaseSubsystem implements 
         this.assertionManager = assertionManager;
         pf.setPrefix(this);
 
+        xtablesTargetPose = pf.createPersistentProperty("Xtables Target Pose", "target_pose");
         xtablesCoordinateLocation = pf.createPersistentProperty("Xtables Coordinate Location", "target_waypoints");
         xtablesHeadingLocation = pf.createPersistentProperty("Xtables Heading Location", "target_heading");
 
@@ -57,5 +59,9 @@ public class CoprocessorCommunicationSubsystem extends BaseSubsystem implements 
 
     public String getXtablesHeadingLocation(){
         return xtablesHeadingLocation.get();
+    }
+
+    public String getXtablesTargetPose() {
+        return xtablesTargetPose.get();
     }
 }

--- a/src/test/java/competition/subsystems/drive/DriveToCoralStationWithVisionCommandTest.java
+++ b/src/test/java/competition/subsystems/drive/DriveToCoralStationWithVisionCommandTest.java
@@ -1,0 +1,52 @@
+package competition.subsystems.drive.commands;
+
+import competition.BaseCompetitionTest;
+import org.junit.Test;
+
+import competition.subsystems.pose.Landmarks;
+import competition.subsystems.drive.commands.DriveToWaypointsWithVisionCommand;
+import edu.wpi.first.units.measure.Distance;
+import static edu.wpi.first.units.Units.Inches;
+import static edu.wpi.first.units.Units.Meters;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Transform2d;
+import edu.wpi.first.math.geometry.Translation2d;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import java.util.Arrays;
+
+public class DriveToCoralStationWithVisionCommandTest extends BaseCompetitionTest {
+    Distance getDistanceFromCenterToOuterBumperX = Inches.of(18);
+
+    @Test
+    public void testTranslation() {
+        var distanceToOuterBumerInMeters = getDistanceFromCenterToOuterBumperX.in(Meters);
+        var coralStationPose = Landmarks.getCoralStationSectionPose(Landmarks.CoralStation.LEFT,
+                Landmarks.CoralStationSection.MID);
+        var distance = Math.sqrt(Math.pow(distanceToOuterBumerInMeters, 2.0) * 2.0);
+        var deltaTranslation = new Translation2d(distance, coralStationPose.getRotation());
+        var destinationTranslation = coralStationPose.getTranslation().plus(deltaTranslation);
+        var destinationPose = new Pose2d(destinationTranslation, coralStationPose.getRotation());
+
+        var expectedFinalX = coralStationPose.getX() + (coralStationPose.getRotation().getCos() * distance);
+        var expectedFinalY = coralStationPose.getY() + (coralStationPose.getRotation().getSin() * distance);
+        assertEquals(expectedFinalX, destinationPose.getX(), 0.001);
+        assertEquals(expectedFinalY, destinationPose.getY(), 0.001);
+        assertEquals(destinationPose.getRotation(), coralStationPose.getRotation());
+    }
+
+    @Test
+    public void testAreListEqual() {
+        var firstList = Arrays.asList(1, 3, 5, 7);
+        var secondList = Arrays.asList(1, 3, 5);
+
+        assertFalse(DriveToWaypointsWithVisionCommand.areListsEqual(firstList, secondList));
+        secondList = Arrays.asList(1, 3, 5, 7);
+        assertTrue(DriveToWaypointsWithVisionCommand.areListsEqual(firstList, secondList));
+        secondList = Arrays.asList(1, 5, 3, 7);
+        assertFalse(DriveToWaypointsWithVisionCommand.areListsEqual(firstList, secondList));
+    }
+}


### PR DESCRIPTION
# Why are we doing this?

Asana task URL:

# Whats changing?
Adding the ability to use Vision path planning to avoid obstacles for designated locations.

Currently set to the only april tag on our setup field, will update to any coral station based on location and which side of the field we are operating on.

Still needs the corresponding code on Alt side.

# Questions/notes for reviewers

# How this was tested
- [ ] tested on robot
- [ ] tested in simulator
- [x] unit tests added

## Video/screenshots (from simulator or live robot)

-----

PR feedback legend

 
| Symbol | Meaning                  |
|--------|--------------------------|
| :star: :star: :star:     | must be addressed                 |
| :star: :star:     | should be addressed        |
| :star:     | something to consider, a good idea                  |
