### PR TITLE
Trapezoid profile manager: store prev setpoint internally 

### DIFF
--- a/src/main/java/competition/motion/TrapezoidProfileManager.java
+++ b/src/main/java/competition/motion/TrapezoidProfileManager.java
@@ -33,9 +33,9 @@ public class TrapezoidProfileManager {
     TrapezoidProfile.Constraints constraints;
     TrapezoidProfile.State initialState;
     TrapezoidProfile.State goalState;
-    MutTime profileStartTime = Seconds.of(-10000).mutableCopy();
+    MutTime profileStartTime = Seconds.mutable(0);
     double previousSetpoint = 0;
-    MutTime previousSetpointTime = Seconds.zero().mutableCopy();
+    MutTime previousSetpointTime = Seconds.mutable(-10000);
 
     @AssistedInject
     public TrapezoidProfileManager(

--- a/src/main/java/competition/motion/TrapezoidProfileManager.java
+++ b/src/main/java/competition/motion/TrapezoidProfileManager.java
@@ -33,7 +33,7 @@ public class TrapezoidProfileManager {
     TrapezoidProfile.Constraints constraints;
     TrapezoidProfile.State initialState;
     TrapezoidProfile.State goalState;
-    MutTime profileStartTime = Seconds.zero().mutableCopy();
+    MutTime profileStartTime = Seconds.of(-10000).mutableCopy();
     double previousSetpoint = 0;
     MutTime previousSetpointTime = Seconds.zero().mutableCopy();
 

--- a/src/main/java/competition/motion/TrapezoidProfileManager.java
+++ b/src/main/java/competition/motion/TrapezoidProfileManager.java
@@ -6,6 +6,7 @@ import dagger.assisted.Assisted;
 import dagger.assisted.AssistedFactory;
 import dagger.assisted.AssistedInject;
 import edu.wpi.first.math.trajectory.TrapezoidProfile;
+import edu.wpi.first.units.measure.MutTime;
 import edu.wpi.first.units.measure.Time;
 import xbot.common.controls.sensors.XTimer;
 import xbot.common.properties.DoubleProperty;
@@ -29,7 +30,9 @@ public class TrapezoidProfileManager {
     TrapezoidProfile.Constraints constraints;
     TrapezoidProfile.State initialState;
     TrapezoidProfile.State goalState;
-    Time profileStartTime = Seconds.zero(); 
+    MutTime profileStartTime = Seconds.zero().mutableCopy();
+    double previousSetpoint = 0;
+    MutTime previousSetpointTime = Seconds.zero().mutableCopy();
 
     @AssistedInject
     public TrapezoidProfileManager(
@@ -48,7 +51,7 @@ public class TrapezoidProfileManager {
         goalState = new TrapezoidProfile.State(initialPosition, 0);
     }
 
-    public void setTargetPosition(double targetValue, double currentValue, double currentVelocity, double previousSetpoint) {
+    public void setTargetPosition(double targetValue, double currentValue, double currentVelocity) {
         // if the profile's constraints properties have changed, recompute the profile
         // there's maybe a better place to do this but this should be fine since setTarget will be called
         // over and over again
@@ -59,9 +62,16 @@ public class TrapezoidProfileManager {
 
         // if the target has changed, recompute the goal and current states
         if(goalState.position != targetValue) {
+            // if the previousSentpoint we have is very recent, use it as the initial state to
+            // avoid discontinuities in the profile
+            if(XTimer.getFPGATimestampTime().minus(previousSetpointTime).in(Seconds) < 0.1) {
+                initialState = new TrapezoidProfile.State(previousSetpoint, currentVelocity);
+            } else {
+                initialState = new TrapezoidProfile.State(currentValue, currentVelocity);
+            }
             initialState = new TrapezoidProfile.State(previousSetpoint, currentVelocity);
             goalState = new TrapezoidProfile.State(targetValue, 0);
-            profileStartTime = XTimer.getFPGATimestampTime().minus(Seconds.of(0.02));
+            profileStartTime.mut_replace(XTimer.getFPGATimestampTime().minus(Seconds.of(0.02)));
         }
 
     }
@@ -69,6 +79,8 @@ public class TrapezoidProfileManager {
     // currently only doing position, but in theory this goal has a velocity associated with it too we could use
     public double getRecommendedPositionForTime() {
         var setpoint = profile.calculate(XTimer.getFPGATimestampTime().minus(profileStartTime).in(Seconds), initialState, goalState);
+        this.previousSetpointTime.mut_replace(XTimer.getFPGATimestampTime());
+        previousSetpoint = setpoint.position;
         return setpoint.position;
     }
     

--- a/src/main/java/competition/motion/TrapezoidProfileManager.java
+++ b/src/main/java/competition/motion/TrapezoidProfileManager.java
@@ -2,17 +2,20 @@ package competition.motion;
 
 import static edu.wpi.first.units.Units.Seconds;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import dagger.assisted.Assisted;
 import dagger.assisted.AssistedFactory;
 import dagger.assisted.AssistedInject;
 import edu.wpi.first.math.trajectory.TrapezoidProfile;
 import edu.wpi.first.units.measure.MutTime;
-import edu.wpi.first.units.measure.Time;
 import xbot.common.controls.sensors.XTimer;
 import xbot.common.properties.DoubleProperty;
 import xbot.common.properties.PropertyFactory;
 
 public class TrapezoidProfileManager {
+    protected final Logger log;
 
     @AssistedFactory
     public abstract static class Factory {
@@ -42,6 +45,7 @@ public class TrapezoidProfileManager {
             @Assisted("defaultMaxAcceleration") double defaultMaxAcceleration,
             @Assisted("initialPosition") double initialPosition) {
         pf.setPrefix(name);
+        log = LogManager.getLogger(name + ": TrapezoidProfileManager");
         maxVelocity = pf.createPersistentProperty("maxVelocity", defaultMaxVelocity);
         maxAcceleration = pf.createPersistentProperty("maxAcceleration", defaultMaxAcceleration);
         constraints = new TrapezoidProfile.Constraints(maxVelocity.get(), maxAcceleration.get());
@@ -69,7 +73,6 @@ public class TrapezoidProfileManager {
             } else {
                 initialState = new TrapezoidProfile.State(currentValue, currentVelocity);
             }
-            initialState = new TrapezoidProfile.State(previousSetpoint, currentVelocity);
             goalState = new TrapezoidProfile.State(targetValue, 0);
             profileStartTime.mut_replace(XTimer.getFPGATimestampTime().minus(Seconds.of(0.02)));
         }

--- a/src/main/java/competition/subsystems/algae_arm/commands/AlgaeArmMaintainerCommand.java
+++ b/src/main/java/competition/subsystems/algae_arm/commands/AlgaeArmMaintainerCommand.java
@@ -26,8 +26,6 @@ public class AlgaeArmMaintainerCommand extends BaseMaintainerCommand<Angle> {
 
     final TrapezoidProfileManager profileManager;
 
-    double setpoint = 0;
-
     @Inject
     public AlgaeArmMaintainerCommand(AlgaeArmSubsystem algaeArm, PropertyFactory pf,
                                      HumanVsMachineDecider.HumanVsMachineDeciderFactory hvm,
@@ -51,7 +49,6 @@ public class AlgaeArmMaintainerCommand extends BaseMaintainerCommand<Angle> {
     @Override
     public void initialize() {
         log.info("Initializing");
-        setpoint = algaeArm.getCurrentValue().in(Degrees);
     }
 
     @Override
@@ -65,9 +62,8 @@ public class AlgaeArmMaintainerCommand extends BaseMaintainerCommand<Angle> {
                 algaeArm.getTargetValue().in(Degrees),
                 algaeArm.getCurrentValue().in(Degree),
                 algaeArm.getCurrentVelocity().in(DegreesPerSecond),
-                setpoint
         );
-        setpoint = profileManager.getRecommendedPositionForTime();
+        var setpoint = profileManager.getRecommendedPositionForTime();
 
         aKitLog.record("ProfileTarget", setpoint);
 

--- a/src/main/java/competition/subsystems/algae_arm/commands/AlgaeArmMaintainerCommand.java
+++ b/src/main/java/competition/subsystems/algae_arm/commands/AlgaeArmMaintainerCommand.java
@@ -61,7 +61,7 @@ public class AlgaeArmMaintainerCommand extends BaseMaintainerCommand<Angle> {
         profileManager.setTargetPosition(
                 algaeArm.getTargetValue().in(Degrees),
                 algaeArm.getCurrentValue().in(Degree),
-                algaeArm.getCurrentVelocity().in(DegreesPerSecond),
+                algaeArm.getCurrentVelocity().in(DegreesPerSecond)
         );
         var setpoint = profileManager.getRecommendedPositionForTime();
 

--- a/src/main/java/competition/subsystems/coral_arm/commands/CoralArmMaintainerCommand.java
+++ b/src/main/java/competition/subsystems/coral_arm/commands/CoralArmMaintainerCommand.java
@@ -38,8 +38,6 @@ public class CoralArmMaintainerCommand extends BaseMaintainerCommand<Angle> {
 
     final Alert collisionSafetiesEngaged = new Alert("Coral Arm: collision safeties engaged", Alert.AlertType.kWarning);
 
-    double setpoint = 0;
-
     @Inject
     public CoralArmMaintainerCommand(CoralArmSubsystem armPivotSubsystem, ElevatorSubsystem elevator,
                                      AlgaeArmSubsystem algaeArm, PropertyFactory pf,
@@ -68,7 +66,6 @@ public class CoralArmMaintainerCommand extends BaseMaintainerCommand<Angle> {
     @Override
     public void initialize() {
         super.initialize();
-        setpoint = coralArm.getCurrentValue().in(Degrees);
     }
 
     @Override
@@ -92,9 +89,8 @@ public class CoralArmMaintainerCommand extends BaseMaintainerCommand<Angle> {
         profileManager.setTargetPosition(
                 currentTarget.in(Degrees),
                 coralArm.getCurrentValue().in(Degree),
-                coralArm.getCurrentVelocity().in(DegreesPerSecond),
-                setpoint);
-        setpoint = profileManager.getRecommendedPositionForTime();
+                coralArm.getCurrentVelocity().in(DegreesPerSecond));
+        var setpoint = profileManager.getRecommendedPositionForTime();
 
         aKitLog.record("ProfileTarget", setpoint);
 

--- a/src/main/java/competition/subsystems/elevator/commands/ElevatorMaintainerCommand.java
+++ b/src/main/java/competition/subsystems/elevator/commands/ElevatorMaintainerCommand.java
@@ -79,14 +79,11 @@ public class ElevatorMaintainerCommand extends BaseMaintainerCommand<Distance> {
     public void initialize() {
         super.initialize();
         calibrationDecider.reset();
-
-        setpoint = elevator.getCurrentValue().in(Meters);
     }
 
     @Override
     protected void initializeMachineControlAction() {
         super.initializeMachineControlAction();
-        setpoint = elevator.getCurrentValue().in(Meters);
     }
 
     @Override
@@ -94,23 +91,18 @@ public class ElevatorMaintainerCommand extends BaseMaintainerCommand<Distance> {
         elevator.setPower(0);
     }
 
-    double setpoint = 0;
-
     @Override
     protected void calibratedMachineControlAction() {
         profileManager.setTargetPosition(
             elevator.getTargetValue().in(Meters),
             elevator.getCurrentValue().in(Meters),
-            elevator.getCurrentVelocity().in(MetersPerSecond),
-            setpoint
+            elevator.getCurrentVelocity().in(MetersPerSecond)
         );
-        setpoint = profileManager.getRecommendedPositionForTime();
+        var setpoint = profileManager.getRecommendedPositionForTime();
 
         // it's helpful to log this to know where the robot is actually trying to get to in the moment
         aKitLog.record("elevatorProfileTarget", setpoint);
 
-        // TODO: this is disabled for testing
-        //handles pidding via motor controller and setting power to elevator
         elevator.masterMotor.setPositionTarget(
                 Rotations.of(setpoint * elevator.rotationsPerMeter.get()
                         + elevator.getElevatorPositionOffsetInRotations()),

--- a/src/test/java/competition/motion/TrapezoidProfileManagerTest.java
+++ b/src/test/java/competition/motion/TrapezoidProfileManagerTest.java
@@ -18,7 +18,7 @@ public class TrapezoidProfileManagerTest extends BaseCompetitionTest {
 
     @Test
     public void setTargetPosition() {
-        manager.setTargetPosition(1, 0, 0, 0);
+        manager.setTargetPosition(1, 0, 0);
         assertEquals(1, manager.goalState.position, 0.001);
         assertEquals(0, manager.goalState.velocity, 0.001);
         assertEquals(0, manager.initialState.position, 0.001);
@@ -33,14 +33,14 @@ public class TrapezoidProfileManagerTest extends BaseCompetitionTest {
 
     @Test
     public void endToEndTest() {
-        manager.setTargetPosition(1, 0, 0, 0);
+        manager.setTargetPosition(1, 0, 0);
         var recommendation = manager.getRecommendedPositionForTime();
         assertEquals(0, recommendation, 0.001);
         timer.advanceTimeInSecondsBy(1);
         recommendation = manager.getRecommendedPositionForTime();
         assertEquals(0.5198, recommendation, 0.001);
 
-        manager.setTargetPosition(2, 1, 0.5, 1);
+        manager.setTargetPosition(2, 1, 0.5);
         recommendation = manager.getRecommendedPositionForTime();
         assertEquals(1.0102, recommendation, 0.001);
         timer.advanceTimeInSecondsBy(1);

--- a/src/test/java/competition/motion/TrapezoidProfileManagerTest.java
+++ b/src/test/java/competition/motion/TrapezoidProfileManagerTest.java
@@ -40,6 +40,8 @@ public class TrapezoidProfileManagerTest extends BaseCompetitionTest {
         recommendation = manager.getRecommendedPositionForTime();
         assertEquals(0.5198, recommendation, 0.001);
 
+        timer.advanceTimeInSecondsBy(1);
+
         manager.setTargetPosition(2, 1, 0.5);
         recommendation = manager.getRecommendedPositionForTime();
         assertEquals(1.0102, recommendation, 0.001);


### PR DESCRIPTION
# Why are we doing this?

and only use it on reset if it's been recently used.

This fixes the bug where after disabling the robot and the elevator drops down, when you renable it it was using the previous setpoint to start the profile.

Asana task URL:

# Whats changing?

# Questions/notes for reviewers

# How this was tested
- [ ] tested on robot
- [x] tested in simulator
- [ ] unit tests added

## Video/screenshots (from simulator or live robot)

-----

PR feedback legend

 
| Symbol | Meaning                  |
|--------|--------------------------|
| :star: :star: :star:     | must be addressed                 |
| :star: :star:     | should be addressed        |
| :star:     | something to consider, a good idea                  |
