### PR TITLE
Fix swerve module positions for 2025 and update SCL

### DIFF
--- a/src/main/java/competition/electrical_contract/Contract2025.java
+++ b/src/main/java/competition/electrical_contract/Contract2025.java
@@ -274,10 +274,10 @@ public class Contract2025 extends ElectricalContract {
     public XYPair getSwerveModuleOffsetsInInches(SwerveInstance swerveInstance) {
         // Update these XYPairs with the swerve module locations!!! (In inches)
         return switch (swerveInstance.label()) {
-            case "FrontLeftDrive" -> new XYPair(15, 15);
-            case "FrontRightDrive" -> new XYPair(15, -15);
-            case "RearLeftDrive" -> new XYPair(-15, 15);
-            case "RearRightDrive" -> new XYPair(-15, -15);
+            case "FrontLeftDrive" -> new XYPair(12, 12);
+            case "FrontRightDrive" -> new XYPair(12, -12);
+            case "RearLeftDrive" -> new XYPair(-12, 12);
+            case "RearRightDrive" -> new XYPair(-12, -12);
             default -> new XYPair(0, 0);
         };
     }


### PR DESCRIPTION
# Why are we doing this?
Swerve module math depends on the positions of each swerve module in space.
On the 2025 robot, the wheels are spaced 24" apart (center to center) in a square arrangement.

# Whats changing?
Adjusted the swerve module positions to reflect the 24" spacing on the 2025 robot.
Updated SCL after verifying on 2024 robot.

# Questions/notes for reviewers

# How this was tested
- [x] tested on robot
- [ ] tested in simulator
- [ ] unit tests added

## Video/screenshots (from simulator or live robot)

-----

PR feedback legend

 
| Symbol | Meaning                  |
|--------|--------------------------|
| :star: :star: :star:     | must be addressed                 |
| :star: :star:     | should be addressed        |
| :star:     | something to consider, a good idea                  |
