### PR TITLE
Calibrate swerve drive from contract

### DIFF
--- a/src/main/java/competition/electrical_contract/Contract2024.java
+++ b/src/main/java/competition/electrical_contract/Contract2024.java
@@ -148,6 +148,16 @@ public class Contract2024 extends Contract2025 {
         };
     }
 
+    @Override
+    public double getSteeringGearRatio() {
+        return 12.8; // Documented for Swerve Specialties MK4
+    }
+
+    @Override
+    public double getDriveGearRatio() {
+        return 6.12; // Documented value for Swerve Specialties MK4 with L3 ratio.
+    }
+
     public DeviceInfo getLightsDio0() {
         return new DeviceInfo("Lights0", 0);
     }

--- a/src/main/java/competition/electrical_contract/Contract2025.java
+++ b/src/main/java/competition/electrical_contract/Contract2025.java
@@ -282,6 +282,16 @@ public class Contract2025 extends ElectricalContract {
         };
     }
 
+    @Override
+    public double getSteeringGearRatio() {
+        return 12.1; // Documented value for WCP x2i.
+    }
+
+    @Override
+    public double getDriveGearRatio() {
+        return 6.48; // Documented value for WCP x2i with X3 10t gears.
+    }
+
     private static double frontAprilCameraXDisplacement = 10.14 / PoseSubsystem.INCHES_IN_A_METER;
     private static double frontAprilCameraYDisplacement = 6.535 / PoseSubsystem.INCHES_IN_A_METER;
     private static double frontAprilCameraZDisplacement = 6.7 / PoseSubsystem.INCHES_IN_A_METER;


### PR DESCRIPTION
# Why are we doing this?
Each of our robots has different swerve module gear ratios. We want to generate the default scaling values from the physical parameters rather than reverting to obviously wrong numbers if properties are lost.

# Whats changing?

# Questions/notes for reviewers

# How this was tested
- [x] tested on robot
- [x] tested in simulator
- [ ] unit tests added

## Video/screenshots (from simulator or live robot)

-----

PR feedback legend

 
| Symbol | Meaning                  |
|--------|--------------------------|
| :star: :star: :star:     | must be addressed                 |
| :star: :star:     | should be addressed        |
| :star:     | something to consider, a good idea                  |
