### PR TITLE
HeadingAssistedDriveAndScore

### DIFF
--- a/src/main/java/competition/commandgroups/DriveToFaceAndScoreCommandGroupFactory.java
+++ b/src/main/java/competition/commandgroups/DriveToFaceAndScoreCommandGroupFactory.java
@@ -30,7 +30,7 @@ public class DriveToFaceAndScoreCommandGroupFactory {
 
         var driveToReefWhilePrepping = new ParallelCommandGroup();
         var driveToReefFaceThenAlign = driveToReefFaceThenAlignCommandGroupFactory.create(targetReefFace);
-        var prepCoralSystem = prepCoralSystemFactory.create(targetLevel);
+        var prepCoralSystem = prepCoralSystemFactory.create(() -> targetLevel);
         driveToReefWhilePrepping.addCommands(driveToReefFaceThenAlign, prepCoralSystem);
 
         var scoreWhenReady = scoreWhenReadyProvider.get();

--- a/src/main/java/competition/commandgroups/DriveToStationAndIntakeUntilCollectedCommandGroupFactory.java
+++ b/src/main/java/competition/commandgroups/DriveToStationAndIntakeUntilCollectedCommandGroupFactory.java
@@ -27,7 +27,7 @@ public class DriveToStationAndIntakeUntilCollectedCommandGroupFactory {
     public ParallelDeadlineGroup create(Landmarks.CoralStation station,
                                         Landmarks.CoralStationSection section) {
         var driveToCoralStationSectionWhilePrepping = new ParallelCommandGroup();
-        var prepCoralSystem = prepCoralSystemCommandGroupFactory.create(Landmarks.CoralLevel.COLLECTING);
+        var prepCoralSystem = prepCoralSystemCommandGroupFactory.create(() -> Landmarks.CoralLevel.COLLECTING);
         driveToCoralStationSectionCommand.setTargetCoralStationSection(station, section);
         driveToCoralStationSectionWhilePrepping.addCommands(driveToCoralStationSectionCommand, prepCoralSystem);
 

--- a/src/main/java/competition/commandgroups/HeadingAssistedDriveAndScoreCommandGroup.java
+++ b/src/main/java/competition/commandgroups/HeadingAssistedDriveAndScoreCommandGroup.java
@@ -1,0 +1,60 @@
+package competition.commandgroups;
+
+import competition.subsystems.coral_scorer.commands.ScoreWhenReadyCommand;
+import competition.subsystems.drive.commands.AlignToReefWithAprilTagCommand;
+import competition.subsystems.drive.commands.DriveToReefFaceFromAngleUntilDetectionCommand;
+import competition.subsystems.drive.commands.MeasureDistanceBeforeScoringCommand;
+import competition.subsystems.pose.Cameras;
+import competition.subsystems.pose.Landmarks;
+import competition.subsystems.pose.PoseSubsystem;
+import dagger.assisted.Assisted;
+import dagger.assisted.AssistedFactory;
+import dagger.assisted.AssistedInject;
+import edu.wpi.first.wpilibj2.command.ParallelCommandGroup;
+import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
+
+import javax.inject.Provider;
+
+public class HeadingAssistedDriveAndScoreCommandGroup extends SequentialCommandGroup {
+    PoseSubsystem pose;
+
+
+    @AssistedFactory
+    public abstract static class Factory {
+        public abstract HeadingAssistedDriveAndScoreCommandGroup create(@Assisted Landmarks.Branch branch);
+    }
+
+    @AssistedInject
+    public HeadingAssistedDriveAndScoreCommandGroup(@Assisted Landmarks.Branch branch,
+                                                    DriveToReefFaceFromAngleUntilDetectionCommand driveToReefFaceFromAngleCommand,
+                                                    PrepCoralSystemCommandGroupFactory prepCoralSystemCommandGroupFactory,
+                                                    ScoreWhenReadyCommand scoreWhenReadyCommand,
+                                                    Provider<AlignToReefWithAprilTagCommand> alignToReefWithAprilTagCommandProvider,
+                                                    MeasureDistanceBeforeScoringCommand measureDistanceBeforeScoringCommand,
+                                                    PoseSubsystem pose) {
+        this.pose = pose;
+        var prep = prepCoralSystemCommandGroupFactory.create(pose::getTargetCoralLevel);
+        var alignToReefWithAprilTagWithCamera = alignToReefWithAprilTagCommandProvider.get();
+
+        if (branch == Landmarks.Branch.A) {
+            alignToReefWithAprilTagWithCamera.setConfigurations(Cameras.FRONT_RIGHT_CAMERA.getIndex(),
+                    false, 0.5);
+            driveToReefFaceFromAngleCommand.setAprilTagCamera(Cameras.FRONT_RIGHT_CAMERA);
+            measureDistanceBeforeScoringCommand.setBranch(Landmarks.Branch.A);
+        }
+        else {
+            alignToReefWithAprilTagWithCamera.setConfigurations(Cameras.FRONT_LEFT_CAMERA.getIndex(),
+                    false, 0.5);
+            driveToReefFaceFromAngleCommand.setAprilTagCamera(Cameras.FRONT_LEFT_CAMERA);
+            measureDistanceBeforeScoringCommand.setBranch(Landmarks.Branch.B);
+        }
+
+        this.addCommands(driveToReefFaceFromAngleCommand);
+        var measureDistanceBeforePrep = new SequentialCommandGroup(measureDistanceBeforeScoringCommand, prep);
+        var alignWhilePrepping = new ParallelCommandGroup(alignToReefWithAprilTagWithCamera, measureDistanceBeforePrep);
+        this.addCommands(alignWhilePrepping);
+        this.addCommands(scoreWhenReadyCommand);
+    }
+
+
+}

--- a/src/main/java/competition/commandgroups/HeadingAssistedDriveAndScoreCommandGroup.java
+++ b/src/main/java/competition/commandgroups/HeadingAssistedDriveAndScoreCommandGroup.java
@@ -36,20 +36,22 @@ public class HeadingAssistedDriveAndScoreCommandGroup extends SequentialCommandG
                                                     MeasureDistanceBeforeScoringCommand measureDistanceBeforeScoringCommand,
                                                     CoralArmSubsystem coralArmSubsystem) {
         this.coralArmSubsystem = coralArmSubsystem;
-        var prep = prepCoralSystemCommandGroupFactory.create(coralArmSubsystem::getTargetCoralLevel);
-        var alignToReefWithAprilTagWithCamera = alignToReefWithAprilTagCommandProvider.get();
+        var prepCoralSystemCommandGroup = prepCoralSystemCommandGroupFactory.create(coralArmSubsystem::getTargetCoralLevel);
+        var alignToReefWithAprilTagWithCameraCommand = alignToReefWithAprilTagCommandProvider.get();
 
         Cameras camera = branch == Landmarks.Branch.A ? Cameras.FRONT_RIGHT_CAMERA : Cameras.FRONT_LEFT_CAMERA;
 
-        alignToReefWithAprilTagWithCamera.setConfigurations(camera.getIndex(),
+        alignToReefWithAprilTagWithCameraCommand.setConfigurations(camera.getIndex(),
                 false, 0.5);
         driveToReefFaceFromAngleCommand.setAprilTagCamera(camera);
         measureDistanceBeforeScoringCommand.setBranch(branch);
 
         this.addCommands(driveToReefFaceFromAngleCommand);
         measureDistanceBeforeScoringCommand.setDistanceThreshold(Meters.of(1));
-        var measureDistanceBeforePrep = new SequentialCommandGroup(measureDistanceBeforeScoringCommand, prep);
-        var alignWhilePrepping = new ParallelCommandGroup(alignToReefWithAprilTagWithCamera, measureDistanceBeforePrep);
+        var measureDistanceBeforePreppingCoralSystem = new SequentialCommandGroup(measureDistanceBeforeScoringCommand,
+                prepCoralSystemCommandGroup);
+        var alignWhilePrepping = new ParallelCommandGroup(alignToReefWithAprilTagWithCameraCommand,
+                measureDistanceBeforePreppingCoralSystem);
         this.addCommands(alignWhilePrepping);
         this.addCommands(scoreWhenReadyCommand);
     }

--- a/src/main/java/competition/commandgroups/HumanLoadUntillCoralCollectedCommandGroup.java
+++ b/src/main/java/competition/commandgroups/HumanLoadUntillCoralCollectedCommandGroup.java
@@ -13,7 +13,7 @@ public class HumanLoadUntillCoralCollectedCommandGroup extends ParallelCommandGr
     public HumanLoadUntillCoralCollectedCommandGroup(PrepCoralSystemCommandGroupFactory prepCoralSystemCommandGroupFactory,
                                                      IntakeUntilCoralCollectedCommand intakeUntilCoralCollectedCommand){
 
-        var prepCoralSystemCommandGroup = prepCoralSystemCommandGroupFactory.create(Landmarks.CoralLevel.COLLECTING);
+        var prepCoralSystemCommandGroup = prepCoralSystemCommandGroupFactory.create(() -> Landmarks.CoralLevel.COLLECTING);
         this.addCommands(intakeUntilCoralCollectedCommand, prepCoralSystemCommandGroup);
     }
 }

--- a/src/main/java/competition/commandgroups/PrepCoralSystemCommandGroupFactory.java
+++ b/src/main/java/competition/commandgroups/PrepCoralSystemCommandGroupFactory.java
@@ -7,6 +7,7 @@ import edu.wpi.first.wpilibj2.command.ParallelCommandGroup;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
+import java.util.function.Supplier;
 
 public class PrepCoralSystemCommandGroupFactory {
 
@@ -21,13 +22,13 @@ public class PrepCoralSystemCommandGroupFactory {
         this.setCoralArmTargetAngleCommandProvider = setCoralArmTargetAngleCommandProvider;
     }
 
-    public ParallelCommandGroup create(Landmarks.CoralLevel coralGoal) {
+    public ParallelCommandGroup create(Supplier<Landmarks.CoralLevel> coralLevelSupplier) {
         var group = new ParallelCommandGroup();
 
         var setElevatorTargetHeightCommand = setElevatorTargetHeightCommandProvider.get();
-        setElevatorTargetHeightCommand.setHeight(coralGoal);
+        setElevatorTargetHeightCommand.setHeightSupplier(coralLevelSupplier);
         var setCoralArmTargetAngleCommand = setCoralArmTargetAngleCommandProvider.get();
-        setCoralArmTargetAngleCommand.setAngle(coralGoal);
+        setCoralArmTargetAngleCommand.setAngleSupplier(coralLevelSupplier);
 
         group.addCommands(setElevatorTargetHeightCommand, setCoralArmTargetAngleCommand);
 

--- a/src/main/java/competition/operator_interface/OperatorCommandMap.java
+++ b/src/main/java/competition/operator_interface/OperatorCommandMap.java
@@ -81,9 +81,9 @@ public class OperatorCommandMap {
 
         // since there are a lot of free buttons on the driver gamepad currently, let's map some
         // for basic scoring control to make it easier to demo solo. These can all be removed later.
-        var prepL4 = prepCoralSystemCommandGroupFactory.create(Landmarks.CoralLevel.FOUR);
+        var prepL4 = prepCoralSystemCommandGroupFactory.create(() -> Landmarks.CoralLevel.FOUR);
         operatorInterface.driverGamepad.getifAvailable(XXboxController.XboxButton.Y).onTrue(prepL4);
-        var homed = prepCoralSystemCommandGroupFactory.create(Landmarks.CoralLevel.COLLECTING);
+        var homed = prepCoralSystemCommandGroupFactory.create(() -> Landmarks.CoralLevel.COLLECTING);
         operatorInterface.driverGamepad.getifAvailable(XXboxController.XboxButton.B).onTrue(homed);
 
         operatorInterface.driverGamepad.getPovIfAvailable(0).onTrue(debugModule);
@@ -102,28 +102,31 @@ public class OperatorCommandMap {
                                       ScoreCoralCommand scoreCoralCommand, IntakeUntilCoralCollectedCommand intakeUntilCoralCollectedCommand,
                                       ScoreWhenReadyCommand scoreWhenReadyCommand, ForceElevatorCalibratedCommand forceElevatorCalibratedCommand,
                                       ForceCoralPivotCalibrated forceCoralPivotCalibratedCommand,
+                                      ForceAlgaeArmCalibrated forceAlgaeArmCalibrated,
                                       Provider<SetAlgaeArmSetpointToTargetPosition> setAlgaeArmProvider,
                                       AlgaeCollectionIntakeCommand intakeAlgae,
                                       AlgaeCollectionOutputCommand ejectAlgae) {
         // Coral system buttons
-        var prepL4 = prepCoralSystemCommandGroupFactory.create(Landmarks.CoralLevel.FOUR);
+        var prepL4 = prepCoralSystemCommandGroupFactory.create(() -> Landmarks.CoralLevel.FOUR);
         oi.operatorGamepad.getifAvailable(XXboxController.XboxButton.Y).onTrue(prepL4);
 
-        var prepL3 = prepCoralSystemCommandGroupFactory.create(Landmarks.CoralLevel.THREE);
+        var prepL3 = prepCoralSystemCommandGroupFactory.create(() -> Landmarks.CoralLevel.THREE);
         oi.operatorGamepad.getifAvailable(XXboxController.XboxButton.X).onTrue(prepL3);
 
-        var prepL2 = prepCoralSystemCommandGroupFactory.create(Landmarks.CoralLevel.TWO);
+        var prepL2 = prepCoralSystemCommandGroupFactory.create(() -> Landmarks.CoralLevel.TWO);
         oi.operatorGamepad.getifAvailable(XXboxController.XboxButton.A).onTrue(prepL2);
 
-        var homed = prepCoralSystemCommandGroupFactory.create(Landmarks.CoralLevel.COLLECTING);
+        var homed = prepCoralSystemCommandGroupFactory.create(() -> Landmarks.CoralLevel.COLLECTING);
         oi.operatorGamepad.getifAvailable(XXboxController.XboxButton.B).onTrue(homed);
         oi.operatorGamepad.getifAvailable(XXboxController.XboxButton.LeftTrigger).whileTrue(intakeUntilCoralCollectedCommand);
-
-//        oi.operatorGamepad.getifAvailable(XXboxController.XboxButton.RightTrigger).whileTrue(scoreWhenReadyCommand);
         oi.operatorGamepad.getifAvailable(XXboxController.XboxButton.RightTrigger).whileTrue(scoreCoralCommand);
 
-        oi.operatorGamepad.getifAvailable(XXboxController.XboxButton.Start).onTrue(forceElevatorCalibratedCommand);
-        oi.operatorGamepad.getifAvailable(XXboxController.XboxButton.Back).onTrue(forceCoralPivotCalibratedCommand);
+        // combine all three claibration commands into one parallal command group
+        var calibrateAll = Commands.parallel(
+                forceElevatorCalibratedCommand,
+                forceCoralPivotCalibratedCommand,
+                forceAlgaeArmCalibrated).ignoringDisable(true);
+        oi.operatorGamepad.getifAvailable(XXboxController.XboxButton.Start).onTrue(calibrateAll);
 
         // Algae system buttons
         var removeLowAlgae = setAlgaeArmProvider.get();
@@ -221,8 +224,8 @@ public class OperatorCommandMap {
     @Inject
     public void setupSysIdCommands(
 
-        DriveSubsystem drive,
-        ElevatorSubsystem elevator
+            DriveSubsystem drive,
+            ElevatorSubsystem elevator
     ) {
 /*
         oi.algaeAndSysIdGamepad.getifAvailable(XXboxController.XboxButton.A)
@@ -261,7 +264,7 @@ public class OperatorCommandMap {
 
     @Inject
     public void setupSimulatorCommands(
-        ResetSimulatedPose resetPose
+            ResetSimulatedPose resetPose
     ) {
         resetPose.includeOnSmartDashboard();
     }

--- a/src/main/java/competition/subsystems/coral_arm/CoralArmSubsystem.java
+++ b/src/main/java/competition/subsystems/coral_arm/CoralArmSubsystem.java
@@ -5,6 +5,8 @@ import competition.subsystems.pose.Landmarks;
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.wpilibj.Alert;
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.Commands;
 import xbot.common.command.BaseSetpointSubsystem;
 import xbot.common.controls.actuators.XCANMotorController;
 import xbot.common.controls.actuators.XCANMotorControllerPIDProperties;
@@ -41,6 +43,8 @@ public class CoralArmSubsystem extends BaseSetpointSubsystem<Angle> {
     public final DoubleProperty humanLoadAngleDegrees;
     public final DoubleProperty rangeOfMotionDegrees;
     public final DoubleProperty powerWhenNotCalibrated;
+
+    public Landmarks.CoralLevel targetCoralLevel;
 
     @Inject
     public CoralArmSubsystem(XCANMotorController.XCANMotorControllerFactory xcanMotorControllerFactory,
@@ -297,5 +301,16 @@ public class CoralArmSubsystem extends BaseSetpointSubsystem<Angle> {
     
     public Angle getHumanLoadAngle() {
         return Degrees.of(this.humanLoadAngleDegrees.get());
+    }
+
+    public Command createSetTargetCoralLevelCommand(Landmarks.CoralLevel coralLevel) {
+        return Commands.runOnce(() -> setTargetCoralLevel(coralLevel));
+    }
+    public void setTargetCoralLevel(Landmarks.CoralLevel coralLevel) {
+        this.targetCoralLevel = coralLevel;
+    }
+
+    public Landmarks.CoralLevel getTargetCoralLevel() {
+        return this.targetCoralLevel;
     }
 }

--- a/src/main/java/competition/subsystems/coral_arm/commands/SetCoralArmTargetAngleCommand.java
+++ b/src/main/java/competition/subsystems/coral_arm/commands/SetCoralArmTargetAngleCommand.java
@@ -5,11 +5,12 @@ import competition.subsystems.pose.Landmarks;
 import xbot.common.command.BaseSetpointCommand;
 
 import javax.inject.Inject;
+import java.util.function.Supplier;
 
 public class SetCoralArmTargetAngleCommand extends BaseSetpointCommand {
 
-    Landmarks.CoralLevel angle;
     CoralArmSubsystem coralArm;
+    private Supplier<Landmarks.CoralLevel> angleSupplier;
 
     @Inject
     public SetCoralArmTargetAngleCommand(CoralArmSubsystem coralArm) {
@@ -20,7 +21,7 @@ public class SetCoralArmTargetAngleCommand extends BaseSetpointCommand {
     @Override
     public void initialize() {
         log.info("Initializing");
-        coralArm.setTargetAngle(angle);
+        coralArm.setTargetAngle(this.angleSupplier.get());
     }
 
     @Override
@@ -33,5 +34,10 @@ public class SetCoralArmTargetAngleCommand extends BaseSetpointCommand {
         return true;
     }
 
-    public void setAngle(Landmarks.CoralLevel angle) { this.angle = angle; }
+    public void setAngle(Landmarks.CoralLevel angle) {
+        setAngleSupplier(() -> angle);
+    }
+    public void setAngleSupplier(Supplier<Landmarks.CoralLevel> angleSupplier) {
+        this.angleSupplier = angleSupplier;
+    }
 }

--- a/src/main/java/competition/subsystems/coral_scorer/commands/ScoreWhenReadyCommand.java
+++ b/src/main/java/competition/subsystems/coral_scorer/commands/ScoreWhenReadyCommand.java
@@ -35,7 +35,9 @@ public class ScoreWhenReadyCommand extends BaseCommand {
         if (hasCoral && getIsTargetAngleScoring && armMaintainerAtGoal && elevatorMaintainerAtGoal) {
             coralScorerSubsystem.setCoralScorerState(CoralScorerSubsystem.CoralScorerState.SCORING);
         }
-
+        aKitLog.record("isTargetAngleScoring", getIsTargetAngleScoring);
+        aKitLog.record("armPrepped", armMaintainerAtGoal);
+        aKitLog.record("elevatorPrepped", elevatorMaintainerAtGoal);
     }
 
     @Override

--- a/src/main/java/competition/subsystems/drive/commands/DriveToReefFaceFromAngleUntilDetectionCommand.java
+++ b/src/main/java/competition/subsystems/drive/commands/DriveToReefFaceFromAngleUntilDetectionCommand.java
@@ -2,6 +2,7 @@ package competition.subsystems.drive.commands;
 
 import competition.subsystems.drive.DriveSubsystem;
 import competition.subsystems.oracle.ReefRoutingCircle;
+import competition.subsystems.pose.Cameras;
 import competition.subsystems.pose.Landmarks;
 import competition.subsystems.pose.PoseSubsystem;
 import competition.subsystems.vision.AprilTagVisionSubsystemExtended;
@@ -26,6 +27,7 @@ public class DriveToReefFaceFromAngleUntilDetectionCommand extends SwerveSimpleT
     Pose2d targetReefFacePose;
     ReefRoutingCircle routingCircle;
     boolean kinematics = true;
+    private Cameras camera = Cameras.FRONT_LEFT_CAMERA;
 
     @Inject
     public DriveToReefFaceFromAngleUntilDetectionCommand(DriveSubsystem drive, PoseSubsystem pose,
@@ -62,8 +64,12 @@ public class DriveToReefFaceFromAngleUntilDetectionCommand extends SwerveSimpleT
 
     @Override
     public boolean isFinished() {
-        return aprilTagVisionSubsystem.reefAprilTagCameraHasCorrectTarget(
+        return aprilTagVisionSubsystem.doesCameraBestObservationHaveAprilTagId(camera.getIndex(),
                 aprilTagVisionSubsystem.getTargetAprilTagID(targetReefFacePose))
                 || logic.recommendIsFinished(pose.getCurrentPose2d(), drive.getPositionalPid(), headingModule);
+    }
+
+    public void setAprilTagCamera(Cameras camera) {
+        this.camera = camera;
     }
 }

--- a/src/main/java/competition/subsystems/drive/commands/MeasureDistanceBeforeScoringCommand.java
+++ b/src/main/java/competition/subsystems/drive/commands/MeasureDistanceBeforeScoringCommand.java
@@ -36,8 +36,8 @@ public class MeasureDistanceBeforeScoringCommand extends BaseCommand {
                 .getDistance(targetReefFacePose.getTranslation()));
         aKitLog.record("branch", branch.name());
 
-        return pose.getCurrentPose2d().getTranslation().getDistance(targetReefFacePose.getTranslation()) <
-                distanceThresholdSupplier.get().in(Meters);
+        return pose.getCurrentPose2d().getTranslation().getDistance(targetReefFacePose.getTranslation())
+                < distanceThresholdSupplier.get().in(Meters);
 
     }
 

--- a/src/main/java/competition/subsystems/drive/commands/MeasureDistanceBeforeScoringCommand.java
+++ b/src/main/java/competition/subsystems/drive/commands/MeasureDistanceBeforeScoringCommand.java
@@ -8,11 +8,13 @@ import xbot.common.command.BaseCommand;
 
 import javax.inject.Inject;
 
+import java.util.function.Supplier;
+
 import static edu.wpi.first.units.Units.Meters;
 
 public class MeasureDistanceBeforeScoringCommand extends BaseCommand {
     PoseSubsystem pose;
-    Distance distanceThreshold = Meters.of(1);
+    Supplier<Distance> distanceThresholdSupplier;
     Landmarks.Branch branch = Landmarks.Branch.A;
     @Inject
     public MeasureDistanceBeforeScoringCommand(PoseSubsystem pose) {
@@ -34,8 +36,17 @@ public class MeasureDistanceBeforeScoringCommand extends BaseCommand {
                 .getDistance(targetReefFacePose.getTranslation()));
         aKitLog.record("branch", branch.name());
 
-        return pose.getCurrentPose2d().getTranslation().getDistance(targetReefFacePose.getTranslation()) < distanceThreshold.in(Meters);
+        return pose.getCurrentPose2d().getTranslation().getDistance(targetReefFacePose.getTranslation()) <
+                distanceThresholdSupplier.get().in(Meters);
 
+    }
+
+    public void setDistanceThresholdSupplier(Supplier<Distance> distanceThresholdSupplier) {
+        this.distanceThresholdSupplier = distanceThresholdSupplier;
+    }
+
+    public void setDistanceThreshold(Distance distanceThreshold) {
+        setDistanceThresholdSupplier(() -> distanceThreshold);
     }
 
     public void setBranch(Landmarks.Branch branch) {

--- a/src/main/java/competition/subsystems/drive/commands/MeasureDistanceBeforeScoringCommand.java
+++ b/src/main/java/competition/subsystems/drive/commands/MeasureDistanceBeforeScoringCommand.java
@@ -1,0 +1,44 @@
+package competition.subsystems.drive.commands;
+
+import competition.subsystems.pose.Landmarks;
+import competition.subsystems.pose.PoseSubsystem;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.units.measure.Distance;
+import xbot.common.command.BaseCommand;
+
+import javax.inject.Inject;
+
+import static edu.wpi.first.units.Units.Meters;
+
+public class MeasureDistanceBeforeScoringCommand extends BaseCommand {
+    PoseSubsystem pose;
+    Distance distanceThreshold = Meters.of(1);
+    Landmarks.Branch branch = Landmarks.Branch.A;
+    @Inject
+    public MeasureDistanceBeforeScoringCommand(PoseSubsystem pose) {
+        this.pose = pose;
+    }
+    @Override
+    public void initialize() {
+        log.info("Initializing");
+    }
+    @Override
+    public void execute() {
+        //nothing
+    }
+    @Override
+    public boolean isFinished() {
+        Pose2d targetReefFacePose = Landmarks.getBranchPose(pose.getReefFaceFromAngle(), branch);
+        aKitLog.record("targetReefPose", targetReefFacePose);
+        aKitLog.record("distance ", pose.getCurrentPose2d().getTranslation()
+                .getDistance(targetReefFacePose.getTranslation()));
+        aKitLog.record("branch", branch.name());
+
+        return pose.getCurrentPose2d().getTranslation().getDistance(targetReefFacePose.getTranslation()) < distanceThreshold.in(Meters);
+
+    }
+
+    public void setBranch(Landmarks.Branch branch) {
+        this.branch = branch;
+    }
+}

--- a/src/main/java/competition/subsystems/pose/PoseSubsystem.java
+++ b/src/main/java/competition/subsystems/pose/PoseSubsystem.java
@@ -19,7 +19,6 @@ import edu.wpi.first.units.measure.Distance;
 import static edu.wpi.first.units.Units.Meters;
 
 import edu.wpi.first.wpilibj2.command.Command;
-import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import org.kobe.xbot.JClient.XTablesClient;
 import org.kobe.xbot.Utilities.Entities.BatchedPushRequests;
@@ -49,8 +48,6 @@ public class PoseSubsystem extends BasePoseSubsystem {
 
     // only used when simulating the robot
     protected Optional<SwerveModulePosition[]> simulatedModulePositions = Optional.empty();
-
-    public Landmarks.CoralLevel targetCoralLevel;
 
     @Inject
     public PoseSubsystem(XGyroFactory gyroFactory, PropertyFactory propManager, DriveSubsystem drive,
@@ -319,16 +316,5 @@ public class PoseSubsystem extends BasePoseSubsystem {
         else {
             return Landmarks.ReefFace.FAR_LEFT;
         }
-    }
-
-    public Command createSetTargetCoralLevelCommand(Landmarks.CoralLevel coralLevel) {
-        return Commands.runOnce(() -> setTargetCoralLevel(coralLevel));
-    }
-    public void setTargetCoralLevel(Landmarks.CoralLevel coralLevel) {
-        this.targetCoralLevel = coralLevel;
-    }
-
-    public Landmarks.CoralLevel getTargetCoralLevel() {
-        return this.targetCoralLevel;
     }
 }

--- a/src/main/java/competition/subsystems/pose/PoseSubsystem.java
+++ b/src/main/java/competition/subsystems/pose/PoseSubsystem.java
@@ -19,6 +19,7 @@ import edu.wpi.first.units.measure.Distance;
 import static edu.wpi.first.units.Units.Meters;
 
 import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import org.kobe.xbot.JClient.XTablesClient;
 import org.kobe.xbot.Utilities.Entities.BatchedPushRequests;
@@ -48,6 +49,8 @@ public class PoseSubsystem extends BasePoseSubsystem {
 
     // only used when simulating the robot
     protected Optional<SwerveModulePosition[]> simulatedModulePositions = Optional.empty();
+
+    public Landmarks.CoralLevel targetCoralLevel;
 
     @Inject
     public PoseSubsystem(XGyroFactory gyroFactory, PropertyFactory propManager, DriveSubsystem drive,
@@ -316,5 +319,16 @@ public class PoseSubsystem extends BasePoseSubsystem {
         else {
             return Landmarks.ReefFace.FAR_LEFT;
         }
+    }
+
+    public Command createSetTargetCoralLevelCommand(Landmarks.CoralLevel coralLevel) {
+        return Commands.runOnce(() -> setTargetCoralLevel(coralLevel));
+    }
+    public void setTargetCoralLevel(Landmarks.CoralLevel coralLevel) {
+        this.targetCoralLevel = coralLevel;
+    }
+
+    public Landmarks.CoralLevel getTargetCoralLevel() {
+        return this.targetCoralLevel;
     }
 }


### PR DESCRIPTION
# Why are we doing this?
A new control scheme where the operator sets the target coral level and a driver button will make the robot drive to a target branch and score based on the current robot heading.
Asana task URL:

# Whats changing?
PoseSubsystem, PrepCoralSystemCommandGroupFactory, SetCoralArmTargetAngleCommand, 
# Questions/notes for reviewers

# How this was tested
- [ ] tested on robot
- [x] tested in simulator
- [ ] unit tests added

## Video/screenshots (from simulator or live robot)

-----

PR feedback legend

 
| Symbol | Meaning                  |
|--------|--------------------------|
| :star: :star: :star:     | must be addressed                 |
| :star: :star:     | should be addressed        |
| :star:     | something to consider, a good idea                  |
