### PR TITLE
Attempt to fix elevator jerkiness on enable/disable

### DIFF
--- a/src/main/java/competition/motion/TrapezoidProfileManager.java
+++ b/src/main/java/competition/motion/TrapezoidProfileManager.java
@@ -55,6 +55,13 @@ public class TrapezoidProfileManager {
         goalState = new TrapezoidProfile.State(initialPosition, 0);
     }
 
+    public void resetState(double currentValue, double currentVelocity) {
+        initialState = new TrapezoidProfile.State(currentValue, currentVelocity);
+        goalState = new TrapezoidProfile.State(currentValue, 0);
+        previousSetpoint = currentValue;
+        profileStartTime.mut_replace(XTimer.getFPGATimestampTime().minus(Seconds.of(0.02)));
+    }
+
     public void setTargetPosition(double targetValue, double currentValue, double currentVelocity) {
         // if the profile's constraints properties have changed, recompute the profile
         // there's maybe a better place to do this but this should be fine since setTarget will be called

--- a/src/main/java/competition/subsystems/elevator/commands/ElevatorMaintainerCommand.java
+++ b/src/main/java/competition/subsystems/elevator/commands/ElevatorMaintainerCommand.java
@@ -74,11 +74,17 @@ public class ElevatorMaintainerCommand extends BaseMaintainerCommand<Distance> {
     public void initialize() {
         super.initialize();
         calibrationDecider.reset();
+        profileManager.resetState(
+                elevator.getCurrentValue().in(Meters),
+                elevator.getCurrentVelocity().in(MetersPerSecond));
     }
 
     @Override
     protected void initializeMachineControlAction() {
         super.initializeMachineControlAction();
+        profileManager.resetState(
+                elevator.getCurrentValue().in(Meters),
+                elevator.getCurrentVelocity().in(MetersPerSecond));
     }
 
     @Override

--- a/src/test/java/competition/motion/TrapezoidProfileManagerTest.java
+++ b/src/test/java/competition/motion/TrapezoidProfileManagerTest.java
@@ -48,5 +48,21 @@ public class TrapezoidProfileManagerTest extends BaseCompetitionTest {
         timer.advanceTimeInSecondsBy(1);
         recommendation = manager.getRecommendedPositionForTime();
         assertEquals(1.8169, recommendation, 0.001);
+
+        timer.advanceTimeInSecondsBy(5);
+
+        manager.resetState(5, -1);
+        manager.setTargetPosition(5, 5, -1);
+        recommendation = manager.getRecommendedPositionForTime();
+        assertEquals(4.9802, recommendation, 0.001);
+        timer.advanceTimeInSecondsBy(1);
+        recommendation = manager.getRecommendedPositionForTime();
+        assertEquals(4.500, recommendation, 0.001);
+        timer.advanceTimeInSecondsBy(1);
+        recommendation = manager.getRecommendedPositionForTime();
+        assertEquals(4.922, recommendation, 0.001);
+        timer.advanceTimeInSecondsBy(1);
+        recommendation = manager.getRecommendedPositionForTime();
+        assertEquals(5.0, recommendation, 0.001);
     }
 }


### PR DESCRIPTION
# Why are we doing this?
The elevator has some unexpected motion when enabling after disable.

# Whats changing?
Explicitly reset the state on initializing the maintainer or starting machine control.

# Questions/notes for reviewers

# How this was tested
- [ ] tested on robot
- [ ] tested in simulator
- [x] unit tests added

## Video/screenshots (from simulator or live robot)

-----

PR feedback legend

 
| Symbol | Meaning                  |
|--------|--------------------------|
| :star: :star: :star:     | must be addressed                 |
| :star: :star:     | should be addressed        |
| :star:     | something to consider, a good idea                  |
