### PR TITLE
AlgaeArm Continous Calibration

### DIFF
--- a/src/main/java/competition/subsystems/algae_arm/AlgaeArmSubsystem.java
+++ b/src/main/java/competition/subsystems/algae_arm/AlgaeArmSubsystem.java
@@ -204,6 +204,11 @@ public class AlgaeArmSubsystem extends BaseSetpointSubsystem<Angle> {
         if (electricalContract.isAlgaeArmPivotMotorReady()) {
             armMotor.periodic();
         }
+
+        if (this.isTouchingBottom()) {
+            forceCalibratedHere();
+        }
+
         isNotCalibratedAlert.set(!isCalibrated());
         aKitLog.record("Target Angle", this.getTargetValue().in(Degrees));
         aKitLog.record("Current Angle", this.getCurrentValue().in(Degrees));

--- a/src/main/java/competition/subsystems/algae_arm/commands/AlgaeArmMaintainerCommand.java
+++ b/src/main/java/competition/subsystems/algae_arm/commands/AlgaeArmMaintainerCommand.java
@@ -5,6 +5,7 @@ import competition.operator_interface.OperatorInterface;
 import competition.subsystems.algae_arm.AlgaeArmSubsystem;
 import edu.wpi.first.units.measure.Angle;
 import xbot.common.command.BaseMaintainerCommand;
+import xbot.common.controls.sensors.XXboxController;
 import xbot.common.logic.HumanVsMachineDecider;
 import xbot.common.math.MathUtils;
 import xbot.common.math.PIDManager;
@@ -81,12 +82,15 @@ public class AlgaeArmMaintainerCommand extends BaseMaintainerCommand<Angle> {
 
     @Override
     protected double getHumanInput() {
-        return MathUtils.constrainDouble(
-                MathUtils.deadband(
-                        oi.algaeAndSysIdGamepad.getRightStickY(),
-                        oi.getOperatorGamepadTypicalDeadband(),
-                        (a) -> MathUtils.exponentAndRetainSign(a, 3)),
-                humanMinPower.get(), humanMaxPower.get());
+        if (oi.operatorGamepad.getXboxButton(XXboxController.XboxButton.Back).getAsBoolean()) {
+            return MathUtils.constrainDouble(
+                    MathUtils.deadband(
+                            oi.operatorGamepad.getRightStickY(),
+                            oi.getOperatorGamepadTypicalDeadband(),
+                            (a) -> MathUtils.exponentAndRetainSign(a, 3)),
+                    humanMinPower.get(), humanMaxPower.get());
+        }
+        return 0;
     }
 
     @Override


### PR DESCRIPTION
# Why are we doing this?
To continuously calibrate the algae arm whenever it hits the low sensor. Also I moved the manual algae arm control to the operator gamepad.
Asana task URL:

# Whats changing?

# Questions/notes for reviewers
AlgaeArmSubsytem, AlgaeArmMaintainerCommand
# How this was tested
- [ ] tested on robot
- [ ] tested in simulator
- [ ] unit tests added

## Video/screenshots (from simulator or live robot)

-----

PR feedback legend

 
| Symbol | Meaning                  |
|--------|--------------------------|
| :star: :star: :star:     | must be addressed                 |
| :star: :star:     | should be addressed        |
| :star:     | something to consider, a good idea                  |
