### PR TITLE
When aligning to an April Tag, lock on to a single tag even if it's not the best target

### DIFF
--- a/src/main/java/competition/subsystems/vision/AprilTagVisionSubsystemExtended.java
+++ b/src/main/java/competition/subsystems/vision/AprilTagVisionSubsystemExtended.java
@@ -56,6 +56,17 @@ public class AprilTagVisionSubsystemExtended extends AprilTagVisionSubsystem {
         return new Translation2d(data.getX(), data.getY());
     }
 
+    public Optional<Translation2d> getRobotRelativeLocationOfAprilTag(int cameraToUse, int tagId) {
+        var observation = getTargetObservation(cameraToUse, tagId);
+        return observation.map(obs -> {
+            Translation3d data = obs.cameraToTarget().getTranslation().rotateBy(
+                    getCameraPosition(cameraToUse).getRotation()
+            );
+
+            return new Translation2d(data.getX(), data.getY());
+        });
+    }
+
     /**
      * Returns the Pose3d of an april tag, given that it exists
      * @param targetAprilTagID we are getting the pose for


### PR DESCRIPTION
# Why are we doing this?
If the target tag is no longer the best tag, the robot could lose it. Updated the code to always track a specific tag.

# Whats changing?
Use the new commands on AprilTagVisionSubsystem to track a specific tag rather than the best.

# Questions/notes for reviewers

# How this was tested
- [ ] tested on robot
- [x] tested in simulator
- [ ] unit tests added

## Video/screenshots (from simulator or live robot)
https://github.com/user-attachments/assets/8f2eeabe-9d57-4026-9b04-867ff793a162


-----

PR feedback legend

 
| Symbol | Meaning                  |
|--------|--------------------------|
| :star: :star: :star:     | must be addressed                 |
| :star: :star:     | should be addressed        |
| :star:     | something to consider, a good idea                  |
