### PR TITLE
Sim update: require the robot to be near the human loading for 1s

### DIFF
--- a/src/main/java/competition/simulation/MapleSimulator.java
+++ b/src/main/java/competition/simulation/MapleSimulator.java
@@ -17,6 +17,7 @@ import edu.wpi.first.math.kinematics.SwerveModuleState;
 import edu.wpi.first.units.measure.Distance;
 import xbot.common.advantage.AKitLogger;
 import xbot.common.controls.sensors.mock_adapters.MockGyro;
+import xbot.common.logic.TimeStableValidator;
 
 import static edu.wpi.first.units.Units.Inches;
 import static edu.wpi.first.units.Units.Meters;
@@ -48,6 +49,7 @@ public class MapleSimulator implements BaseSimulator {
     final LightsSimulator lightsSimulator;
 
     final Distance humanLoadingDistanceThreshold = Meters.of(0.5);
+    final TimeStableValidator humanLoadValidator = new TimeStableValidator(1);
 
     // maple-sim stuff ----------------------------
     final DriveTrainSimulationConfig config;
@@ -184,8 +186,9 @@ public class MapleSimulator implements BaseSimulator {
                 }
             }
         }
+        var robotNearHumanStable = humanLoadValidator.checkStable(robotNearHumanLoading);
 
-        if (elevatorAtCollectionHeight && armAtCollectionAngle && coralScorerIsIntaking && robotNearHumanLoading) {
+        if (elevatorAtCollectionHeight && armAtCollectionAngle && coralScorerIsIntaking && robotNearHumanStable) {
             coralScorerSimulator.simulateCoralLoad();
         }
     }

--- a/src/main/java/competition/simulation/MapleSimulator.java
+++ b/src/main/java/competition/simulation/MapleSimulator.java
@@ -48,7 +48,7 @@ public class MapleSimulator implements BaseSimulator {
     final AlgaeArmSimulator algaeArmSimulator;
     final LightsSimulator lightsSimulator;
 
-    final Distance humanLoadingDistanceThreshold = Meters.of(0.5);
+    final Distance humanLoadingDistanceThreshold = Meters.of(0.2);
     final TimeStableValidator humanLoadValidator = new TimeStableValidator(1);
 
     // maple-sim stuff ----------------------------


### PR DESCRIPTION
# Why are we doing this?

Makes the sim robot behave a little more realistically, before it was getting coral too fast. Also tighten the distance away it needs to be (was 0.5m which is bananas)

Asana task URL:

# Whats changing?

# Questions/notes for reviewers

# How this was tested
- [ ] tested on robot
- [ ] tested in simulator
- [ ] unit tests added

## Video/screenshots (from simulator or live robot)

-----

PR feedback legend

 
| Symbol | Meaning                  |
|--------|--------------------------|
| :star: :star: :star:     | must be addressed                 |
| :star: :star:     | should be addressed        |
| :star:     | something to consider, a good idea                  |
