### PR TITLE
Fix reef sim working for red + blue again

### DIFF
--- a/src/main/java/competition/simulation/reef/ReefSimulator.java
+++ b/src/main/java/competition/simulation/reef/ReefSimulator.java
@@ -88,7 +88,7 @@ public class ReefSimulator {
                         var key = new ReefCoralKey(alliance, face, level, post);
                         // TODO: consider some logic to ignore locations that already have coral on them
                         // or otherwise cause the coral to drop to the floor if that happens?
-                        var pose = getCoralPose(key.face, key.level, key.post);
+                        var pose = getCoralPose(key.alliance, key.face, key.level, key.post);
                         var distance = Meters.of(scorerPose.getDistance(pose.getTranslation()));
                         coralDistanceMap.put(key, distance);
                     }
@@ -105,6 +105,7 @@ public class ReefSimulator {
 
     public void scoreCoral(ReefCoralKey coral) {
         reefCoralLocations.add(coral);
+        System.out.println("Scoring coral at " + coral);
     }
 
     public boolean isCoralScored(ReefCoralKey coral) {
@@ -139,7 +140,7 @@ public class ReefSimulator {
     public Pose3d[] getCoralPoses() {
         return reefCoralLocations.stream()
                 .map(coralLocation -> {
-                    Pose3d originalPose = getCoralPose(coralLocation.face(), coralLocation.level(), coralLocation.post());
+                    Pose3d originalPose = getCoralPose(coralLocation.alliance, coralLocation.face(), coralLocation.level(), coralLocation.post());
                     Pose2d pose  = originalPose.toPose2d();
                     Rotation3d desiredRotation = originalPose.getRotation();
 
@@ -159,10 +160,10 @@ public class ReefSimulator {
     }
 
     public Pose3d getCoralPose(ReefCoralKey key) {
-        return getCoralPose(key.face, key.level, key.post);
+        return getCoralPose(key.alliance, key.face, key.level, key.post);
     }
 
-    public Pose3d getCoralPose(ReefFace face, ReefLevel level, ReefPost post) {
+    public Pose3d getCoralPose(Alliance alliance, ReefFace face, ReefLevel level, ReefPost post) {
         // given a reef face, level, and post, return a Pose3d for where that piece of
         // coral is stuck on the reef
         var rotation = getRotationFromFarFace(face);
@@ -176,7 +177,8 @@ public class ReefSimulator {
             default -> new Translation2d();
         };
         var reefCenterToFarPost = reefCenterToFar.plus(level4Adjustment).plus(postTranslation);
-        var algaeTranslation = reefCenterToFarPost.rotateBy(rotation).plus(reefCenter);
+        var adjustedReefCenter = alliance == Alliance.RED ? PoseSubsystem.convertBlueToRed(reefCenter) : reefCenter;
+        var algaeTranslation = reefCenterToFarPost.rotateBy(rotation).plus(adjustedReefCenter);
 
         var z = switch (level) {
             case LEVEL_1 -> 0.5;
@@ -201,7 +203,7 @@ public class ReefSimulator {
     public Pose3d[] getAlgaePoses() {
         return reefAlgaeLocations.stream()
                 .map(algaeLocation -> {
-                    Pose3d originalPose = getAlgaePose(algaeLocation.face(), algaeLocation.level());
+                    Pose3d originalPose = getAlgaePose(algaeLocation.alliance, algaeLocation.face(), algaeLocation.level());
                     Pose2d pose = originalPose.toPose2d();
                     if (algaeLocation.alliance() == Alliance.RED) {
                         pose = PoseSubsystem.convertBluetoRed(pose);
@@ -224,13 +226,14 @@ public class ReefSimulator {
         return rotation;
     }
 
-    public Pose3d getAlgaePose(ReefFace face, ReefLevel level) {
+    public Pose3d getAlgaePose(Alliance alliance, ReefFace face, ReefLevel level) {
         // given a reef face and level, return a Pose3d for where that piece of
         // algae is stuck on the reef
         // TODO: this number isn't right, update it
 
         var rotation = getRotationFromFarFace(face);
-        var algaeTranslation = reefCenterToFar.rotateBy(rotation).plus(reefCenter);
+        var adjustedReefCenter = alliance == Alliance.RED ? PoseSubsystem.convertBlueToRed(reefCenter) : reefCenter;
+        var algaeTranslation = reefCenterToFar.rotateBy(rotation).plus(adjustedReefCenter);
 
         var z = switch (level) {
             case LEVEL_1 -> throw new IllegalArgumentException("Algae can't be on level 1");


### PR DESCRIPTION

# Why are we doing this?

Was missing checking for alliance to find the right reef locations.

Asana task URL:

# Whats changing?

# Questions/notes for reviewers

# How this was tested
- [ ] tested on robot
- [ ] tested in simulator
- [ ] unit tests added

## Video/screenshots (from simulator or live robot)
![image](https://github.com/user-attachments/assets/5c96a18e-003e-4601-87d6-26b7b145b389)

-----

PR feedback legend

 
| Symbol | Meaning                  |
|--------|--------------------------|
| :star: :star: :star:     | must be addressed                 |
| :star: :star:     | should be addressed        |
| :star:     | something to consider, a good idea                  |
