### PR TITLE
Adding back measure distance before prepping

### DIFF
--- a/src/main/java/competition/commandgroups/DriveToFaceAndScoreCommandGroupFactory.java
+++ b/src/main/java/competition/commandgroups/DriveToFaceAndScoreCommandGroupFactory.java
@@ -50,7 +50,7 @@ public class DriveToFaceAndScoreCommandGroupFactory {
         var driveToFaceAndScoreCommandGroup = new SequentialCommandGroup();
 
         // Drive to a branch while prepping the coral system once the robot is close enough
-        var driveToBranchWhilePrepping = new SequentialCommandGroup();
+        var driveToBranchWhilePrepping = new ParallelCommandGroup();
 
         // Terminally approach to branch
         var driveToReefFaceThenAlign = driveToReefFaceThenAlignCommandGroupFactory.create(targetReefFace, targetBranch);
@@ -68,7 +68,7 @@ public class DriveToFaceAndScoreCommandGroupFactory {
         measureDistanceBeforeScoringCommand.setDistanceThreshold(distanceThresholdInMeters);
         measureDistanceBeforeScoringCommand.setBranch(targetBranch);
         var prepCoralSystem = prepCoralSystemFactory.create(() -> targetLevel);
-        measureDistanceThenPrep.addCommands(prepCoralSystem);
+        measureDistanceThenPrep.addCommands(measureDistanceBeforeScoringCommand, prepCoralSystem);
 
         driveToBranchWhilePrepping.addCommands(driveToReefFaceThenAlign, measureDistanceThenPrep);
 


### PR DESCRIPTION
# Why are we doing this?
measure distance before prepping was debugged on the red side in the sim so i'm adding this back

Asana task URL:

# Whats changing?

# Questions/notes for reviewers

# How this was tested
- [ ] tested on robot
- [ ] tested in simulator
- [ ] unit tests added

## Video/screenshots (from simulator or live robot)

-----

PR feedback legend

 
| Symbol | Meaning                  |
|--------|--------------------------|
| :star: :star: :star:     | must be addressed                 |
| :star: :star:     | should be addressed        |
| :star:     | something to consider, a good idea                  |
