### PR TITLE
Cleaned up factory issues, and fixed the core "can only do auto once" bug

### DIFF
--- a/src/main/java/competition/auto_programs/FromLeftCageScoreLeftFacesLevelFours.java
+++ b/src/main/java/competition/auto_programs/FromLeftCageScoreLeftFacesLevelFours.java
@@ -18,8 +18,8 @@ public class FromLeftCageScoreLeftFacesLevelFours extends BaseAutonomousSequenti
     @Inject
     public FromLeftCageScoreLeftFacesLevelFours(AutonomousCommandSelector autoSelector,
                                                 PoseSubsystem pose,
-                                                Provider<DriveToFaceAndScoreCommandGroupFactory> driveToFaceAndScoreFactProv,
-                                                Provider<DriveToStationAndIntakeUntilCollectedCommandGroupFactory> driveToStationAndIntakeFactProv,
+                                                DriveToFaceAndScoreCommandGroupFactory driveToFaceAndScoreFact,
+                                                DriveToStationAndIntakeUntilCollectedCommandGroupFactory driveToStationAndIntakeFact,
                                                 PrepCoralSystemCommandGroupFactory prepCoralSystemCommandGroupFact,
                                                 BaseSimulator simulator) {
         super(autoSelector);
@@ -35,43 +35,43 @@ public class FromLeftCageScoreLeftFacesLevelFours extends BaseAutonomousSequenti
 
         // Drive to far left, branch B and score level four
         queueDriveAndScoreMessageToAutoSelector(Landmarks.ReefFace.FAR_LEFT, Landmarks.Branch.B, Landmarks.CoralLevel.FOUR);
-        var driveAndScoreFarLeftBranchBLevelFour = driveToFaceAndScoreFactProv.get().create(
+        var driveAndScoreFarLeftBranchBLevelFour = driveToFaceAndScoreFact.create(
                 Landmarks.ReefFace.FAR_LEFT, Landmarks.Branch.B, Landmarks.CoralLevel.FOUR);
         this.addCommands(driveAndScoreFarLeftBranchBLevelFour);
 
         // Drive to left coral station and intake coral until collected
         queueDriveAndIntakeMessageToAutoSelector(Landmarks.CoralStation.LEFT, Landmarks.CoralStationSection.MID);
-        var driveToLeftStationAndIntakeFirst = driveToStationAndIntakeFactProv.get().create(
+        var driveToLeftStationAndIntakeFirst = driveToStationAndIntakeFact.create(
                 Landmarks.CoralStation.LEFT, true);
         this.addCommands(driveToLeftStationAndIntakeFirst);
 
         // Drive to close left, branch B and score level four
         queueDriveAndScoreMessageToAutoSelector(Landmarks.ReefFace.CLOSE_LEFT, Landmarks.Branch.B, Landmarks.CoralLevel.FOUR);
-        var driveAndScoreCloseLeftBranchBLevelFour = driveToFaceAndScoreFactProv.get().create(
+        var driveAndScoreCloseLeftBranchBLevelFour = driveToFaceAndScoreFact.create(
                 Landmarks.ReefFace.CLOSE_LEFT, Landmarks.Branch.B, Landmarks.CoralLevel.FOUR);
         this.addCommands(driveAndScoreCloseLeftBranchBLevelFour);
 
         // Drive to left coral station and intake coral until collected
         queueDriveAndIntakeMessageToAutoSelector(Landmarks.CoralStation.LEFT, Landmarks.CoralStationSection.MID);
-        var driveToLeftStationAndIntakeSecond = driveToStationAndIntakeFactProv.get().create(
+        var driveToLeftStationAndIntakeSecond = driveToStationAndIntakeFact.create(
                 Landmarks.CoralStation.LEFT, false);
         this.addCommands(driveToLeftStationAndIntakeSecond);
 
         // Drive to close left, branch A and score level four
         queueDriveAndScoreMessageToAutoSelector(Landmarks.ReefFace.CLOSE_LEFT, Landmarks.Branch.A, Landmarks.CoralLevel.FOUR);
-        var driveAndScoreCloseLeftBranchALevelFour = driveToFaceAndScoreFactProv.get().create(
+        var driveAndScoreCloseLeftBranchALevelFour = driveToFaceAndScoreFact.create(
                 Landmarks.ReefFace.CLOSE_LEFT, Landmarks.Branch.A, Landmarks.CoralLevel.FOUR);
         this.addCommands(driveAndScoreCloseLeftBranchALevelFour);
 
         // Drive to left coral station and intake coral until collected
         queueDriveAndIntakeMessageToAutoSelector(Landmarks.CoralStation.LEFT, Landmarks.CoralStationSection.MID);
-        var driveToLeftStationAndIntakeThird = driveToStationAndIntakeFactProv.get().create(
+        var driveToLeftStationAndIntakeThird = driveToStationAndIntakeFact.create(
                 Landmarks.CoralStation.LEFT, false);
         this.addCommands(driveToLeftStationAndIntakeThird);
 
         // Drive to close, branch A and score level four
         queueDriveAndScoreMessageToAutoSelector(Landmarks.ReefFace.CLOSE, Landmarks.Branch.A, Landmarks.CoralLevel.FOUR);
-        var driveAndScoreCloseBranchALevelFour = driveToFaceAndScoreFactProv.get().create(
+        var driveAndScoreCloseBranchALevelFour = driveToFaceAndScoreFact.create(
                 Landmarks.ReefFace.CLOSE, Landmarks.Branch.A, Landmarks.CoralLevel.FOUR);
         this.addCommands(driveAndScoreCloseBranchALevelFour);
 

--- a/src/main/java/competition/commandgroups/DriveToReefFaceThenAlignCommandGroupFactory.java
+++ b/src/main/java/competition/commandgroups/DriveToReefFaceThenAlignCommandGroupFactory.java
@@ -18,17 +18,14 @@ import java.util.Set;
 
 public class DriveToReefFaceThenAlignCommandGroupFactory {
 
-    Provider<DriveToReefFaceUntilDetectionCommand> driveToReefFaceCommandProvider;
     Provider<AlignToTagGlobalMovementWithCalculator> alignToReefWithAprilTagCommandProvider;
     AprilTagVisionSubsystemExtended aprilTagVisionSubsystem;
     DriveSubsystem drive;
 
     @Inject
-    public DriveToReefFaceThenAlignCommandGroupFactory(Provider<DriveToReefFaceUntilDetectionCommand> driveToReefFaceCommandProvider,
-                                                       Provider<AlignToTagGlobalMovementWithCalculator> alignToReefWithAprilTagCommandProvider,
+    public DriveToReefFaceThenAlignCommandGroupFactory(Provider<AlignToTagGlobalMovementWithCalculator> alignToReefWithAprilTagCommandProvider,
                                                        AprilTagVisionSubsystemExtended aprilTagVisionSubsystem,
                                                        DriveSubsystem drive) {
-        this.driveToReefFaceCommandProvider = driveToReefFaceCommandProvider;
         this.alignToReefWithAprilTagCommandProvider = alignToReefWithAprilTagCommandProvider;
         this.aprilTagVisionSubsystem = aprilTagVisionSubsystem;
         this.drive = drive;
@@ -50,12 +47,9 @@ public class DriveToReefFaceThenAlignCommandGroupFactory {
     public SequentialCommandGroup create(Landmarks.ReefFace targetReefFace, Landmarks.Branch targetBranch) {
         var group = new SequentialCommandGroup();
 
-        var driveToReefFaceCommand = driveToReefFaceCommandProvider.get();
-        var alignToReefWithAprilTagCommand = alignToReefWithAprilTagCommandProvider.get();
-
-        driveToReefFaceCommand.setTargetReefFacePose(targetReefFace);
         var alignToReefCommand = new DeferredCommand(
                 () -> {
+                    var alignToReefWithAprilTagCommand = alignToReefWithAprilTagCommandProvider.get();
                     setBranch(alignToReefWithAprilTagCommand, targetReefFace, targetBranch);
                     return alignToReefWithAprilTagCommand;
                 }, Set.of(drive)

--- a/src/main/java/competition/commandgroups/DriveToStationAndIntakeUntilCollectedCommandGroupFactory.java
+++ b/src/main/java/competition/commandgroups/DriveToStationAndIntakeUntilCollectedCommandGroupFactory.java
@@ -8,30 +8,30 @@ import edu.wpi.first.wpilibj2.command.ParallelDeadlineGroup;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 
 import javax.inject.Inject;
+import javax.inject.Provider;
 
 public class DriveToStationAndIntakeUntilCollectedCommandGroupFactory {
 
-    DriveToCoralStationInterstitialCommand driveToCoralStationSectionCommand;
-    AlignToSpecificHumanLoadingStationCommand alignToCoralStationCommand;
+    Provider<DriveToCoralStationInterstitialCommand> driveToCoralStationSectionCommandProv;
+    Provider<AlignToSpecificHumanLoadingStationCommand> alignToCoralStationCommandProv;
+    Provider<IntakeUntilCoralCollectedCommand> intakeUntilCoralCollectedCommandProv;
     PrepCoralSystemCommandGroupFactory prepCoralSystemCommandGroupFactory;
-    IntakeUntilCoralCollectedCommand intakeUntilCoralCollectedCommand;
-
 
     @Inject
-    public DriveToStationAndIntakeUntilCollectedCommandGroupFactory(DriveToCoralStationInterstitialCommand driveToCoralStationSectionCommand,
-                                                                    AlignToSpecificHumanLoadingStationCommand alignToCoralStationCommand,
+    public DriveToStationAndIntakeUntilCollectedCommandGroupFactory(Provider<DriveToCoralStationInterstitialCommand> driveToCoralStationSectionCommandProv,
+                                                                    Provider<AlignToSpecificHumanLoadingStationCommand> alignToCoralStationCommandProv,
                                                                     PrepCoralSystemCommandGroupFactory prepCoralSystemCommandGroupFactory,
-                                                                    IntakeUntilCoralCollectedCommand intakeUntilCoralCollectedCommand) {
-        this.driveToCoralStationSectionCommand = driveToCoralStationSectionCommand;
-        this.alignToCoralStationCommand = alignToCoralStationCommand;
+                                                                    Provider<IntakeUntilCoralCollectedCommand> intakeUntilCoralCollectedCommandProv) {
+        this.driveToCoralStationSectionCommandProv = driveToCoralStationSectionCommandProv;
+        this.alignToCoralStationCommandProv = alignToCoralStationCommandProv;
         this.prepCoralSystemCommandGroupFactory = prepCoralSystemCommandGroupFactory;
-        this.intakeUntilCoralCollectedCommand = intakeUntilCoralCollectedCommand;
+        this.intakeUntilCoralCollectedCommandProv = intakeUntilCoralCollectedCommandProv;
     }
 
     public ParallelDeadlineGroup create(Landmarks.CoralStation station,
                                          boolean addPoint) {
         // Overarching command group — preps coral system and drives to coral station at the same time, command group stops if a coral is collected
-        var driveUntilIntake = new ParallelDeadlineGroup(intakeUntilCoralCollectedCommand);
+        var driveUntilIntake = new ParallelDeadlineGroup(intakeUntilCoralCollectedCommandProv.get());
 
         // Prep coral system to coral collection
         var prepCoralSystem = prepCoralSystemCommandGroupFactory.create(() -> Landmarks.CoralLevel.COLLECTING);
@@ -41,9 +41,11 @@ public class DriveToStationAndIntakeUntilCollectedCommandGroupFactory {
         var driveToCoralStation = new SequentialCommandGroup();
         // We can add an interstitial point between scoring at the reef and terminally approaching to the coral station to avoid rotating into the reef
         if (addPoint) {
+            var driveToCoralStationSectionCommand = driveToCoralStationSectionCommandProv.get();
             driveToCoralStationSectionCommand.setTargetCoralStationSection(station);
             driveToCoralStation.addCommands(driveToCoralStationSectionCommand.withTimeout(2.0));
         }
+        var alignToCoralStationCommand = alignToCoralStationCommandProv.get();
         alignToCoralStationCommand.setCoralStation(station);
         driveToCoralStation.addCommands(alignToCoralStationCommand);
         driveUntilIntake.addCommands(driveToCoralStation);


### PR DESCRIPTION
# Why are we doing this?
We were having issues where the robot could only run auto once before needing to restart the robot. The error we were seeing was that we were trying to run/schedule a command that was part of a command composition, but I couldn't find an example of incorrect command creation.

Eventually I looked at `DriveToReefFaceThenAlignCommandGroupFactory`, which is notable in that it is the only place where we have used a `DeferredCommand`. Something about how we were reusing the command to be deferred is causing issues with the scheduler. The solution is to move the creation of the deferred command inside the DeferredCommand's constructor. 

Asana task URL:

# Whats changing?

# Questions/notes for reviewers

# How this was tested
- [ ] tested on robot
- [x] tested in simulator
- [ ] unit tests added

## Video/screenshots (from simulator or live robot)

-----

PR feedback legend

 
| Symbol | Meaning                  |
|--------|--------------------------|
| :star: :star: :star:     | must be addressed                 |
| :star: :star:     | should be addressed        |
| :star:     | something to consider, a good idea                  |
