### PR TITLE
Feature/sammamish day 1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -136,7 +136,7 @@ dependencies {
     annotationProcessor 'com.google.dagger:dagger-compiler:2.44.2'
     testAnnotationProcessor 'com.google.dagger:dagger-compiler:2.44.2'
 
-    testImplementation "org.mockito:mockito-core:3.+"
+    testImplementation "org.mockito:mockito-core:3.12.4"
 
     // xtables
     implementation "org.kobe.xbot:xtables:5.4.3"

--- a/src/main/java/competition/commandgroups/DriveToFaceAndScoreCommandGroupFactory.java
+++ b/src/main/java/competition/commandgroups/DriveToFaceAndScoreCommandGroupFactory.java
@@ -6,6 +6,7 @@ import competition.subsystems.pose.Landmarks;
 import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.wpilibj2.command.ParallelCommandGroup;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
+import edu.wpi.first.wpilibj2.command.WaitCommand;
 import xbot.common.properties.DistanceProperty;
 import xbot.common.properties.PropertyFactory;
 
@@ -73,8 +74,9 @@ public class DriveToFaceAndScoreCommandGroupFactory {
         driveToBranchWhilePrepping.addCommands(driveToReefFaceThenAlign, measureDistanceThenPrep);
 
         var scoreWhenReady = scoreWhenReadyProvider.get();
+        var waitBeforeScoring = new WaitCommand(1); // Wait for the wobble to go away
 
-        driveToFaceAndScoreCommandGroup.addCommands(driveToBranchWhilePrepping, scoreWhenReady);
+        driveToFaceAndScoreCommandGroup.addCommands(driveToBranchWhilePrepping, waitBeforeScoring, scoreWhenReady);
 
         return driveToFaceAndScoreCommandGroup;
     }

--- a/src/main/java/competition/commandgroups/DriveToFaceAndScoreCommandGroupFactory.java
+++ b/src/main/java/competition/commandgroups/DriveToFaceAndScoreCommandGroupFactory.java
@@ -74,7 +74,7 @@ public class DriveToFaceAndScoreCommandGroupFactory {
         driveToBranchWhilePrepping.addCommands(driveToReefFaceThenAlign, measureDistanceThenPrep);
 
         var scoreWhenReady = scoreWhenReadyProvider.get();
-        var waitBeforeScoring = new WaitCommand(1); // Wait for the wobble to go away
+        var waitBeforeScoring = new WaitCommand(0.8); // Wait for the wobble to go away
 
         driveToFaceAndScoreCommandGroup.addCommands(driveToBranchWhilePrepping, waitBeforeScoring, scoreWhenReady);
 

--- a/src/main/java/competition/electrical_contract/Contract2025.java
+++ b/src/main/java/competition/electrical_contract/Contract2025.java
@@ -10,11 +10,13 @@ import edu.wpi.first.math.geometry.Rotation3d;
 
 import competition.subsystems.pose.PoseSubsystem;
 import edu.wpi.first.units.measure.Distance;
+import xbot.common.controls.sensors.XGyro;
 import xbot.common.injection.electrical_contract.CANBusId;
 import xbot.common.injection.electrical_contract.CANMotorControllerInfo;
 import xbot.common.injection.electrical_contract.CANMotorControllerOutputConfig;
 import xbot.common.injection.electrical_contract.CameraInfo;
 import xbot.common.injection.electrical_contract.DeviceInfo;
+import xbot.common.injection.electrical_contract.IMUInfo;
 import xbot.common.injection.electrical_contract.MotorControllerType;
 import xbot.common.injection.electrical_contract.CANMotorControllerOutputConfig.InversionType;
 import xbot.common.injection.swerve.SwerveInstance;
@@ -281,6 +283,16 @@ public class Contract2025 extends ElectricalContract {
             case "RearRightDrive" -> new XYPair(-12, -12);
             default -> new XYPair(0, 0);
         };
+    }
+
+    @Override
+    public IMUInfo getNavXGyroInfo() {
+        return new IMUInfo("IMU", XGyro.ImuType.navX, XGyro.InterfaceType.spi, null, 1);
+    }
+
+    @Override
+    public IMUInfo getPigeon2GyroInfo() {
+        return new IMUInfo("IMU_Pigeon2", XGyro.ImuType.pigeon2, null, CANBusId.DefaultCanivore, 10);
     }
 
     @Override

--- a/src/main/java/competition/electrical_contract/ElectricalContract.java
+++ b/src/main/java/competition/electrical_contract/ElectricalContract.java
@@ -4,13 +4,15 @@ import static edu.wpi.first.units.Units.Meters;
 import edu.wpi.first.units.measure.Distance;
 import xbot.common.injection.electrical_contract.CANMotorControllerInfo;
 import xbot.common.injection.electrical_contract.DeviceInfo;
+import xbot.common.injection.electrical_contract.IMUInfo;
 import xbot.common.injection.electrical_contract.XCameraElectricalContract;
 import xbot.common.injection.electrical_contract.XDeadwheelElectricalContract;
 import xbot.common.injection.electrical_contract.XSwerveDriveElectricalContract;
 import xbot.common.injection.swerve.SwerveInstance;
 import xbot.common.math.XYPair;
 
-public abstract class ElectricalContract implements XSwerveDriveElectricalContract, XCameraElectricalContract, XDeadwheelElectricalContract {
+public abstract class ElectricalContract implements XSwerveDriveElectricalContract, XCameraElectricalContract,
+        XDeadwheelElectricalContract {
 
     public abstract boolean isDriveReady();
 
@@ -23,6 +25,10 @@ public abstract class ElectricalContract implements XSwerveDriveElectricalContra
     public abstract DeviceInfo getSteeringEncoder(SwerveInstance swerveInstance);
 
     public abstract XYPair getSwerveModuleOffsetsInInches(SwerveInstance swerveInstance);
+
+    public abstract IMUInfo getNavXGyroInfo();
+
+    public abstract IMUInfo getPigeon2GyroInfo();
 
     public abstract boolean isElevatorReady();
 

--- a/src/main/java/competition/injection/modules/CommonModule.java
+++ b/src/main/java/competition/injection/modules/CommonModule.java
@@ -12,6 +12,7 @@ import dagger.Provides;
 import edu.wpi.first.apriltag.AprilTagFieldLayout;
 import edu.wpi.first.apriltag.AprilTagFields;
 import xbot.common.injection.electrical_contract.XCameraElectricalContract;
+import xbot.common.injection.electrical_contract.XDeadwheelElectricalContract;
 import xbot.common.injection.electrical_contract.XSwerveDriveElectricalContract;
 import xbot.common.injection.swerve.FrontLeftDrive;
 import xbot.common.injection.swerve.FrontRightDrive;
@@ -83,6 +84,10 @@ public abstract class CommonModule {
     @Binds
     @Singleton
     public abstract XCameraElectricalContract getCameraContract(ElectricalContract impl);
+
+    @Binds
+    @Singleton
+    public abstract XDeadwheelElectricalContract getDeadwheelContract(ElectricalContract impl);
 
     @Binds
     @Singleton

--- a/src/main/java/competition/injection/modules/Module2023.java
+++ b/src/main/java/competition/injection/modules/Module2023.java
@@ -4,17 +4,8 @@ import competition.electrical_contract.Contract2023;
 import competition.electrical_contract.ElectricalContract;
 import competition.simulation.BaseSimulator;
 import competition.simulation.NoopSimulator;
-import competition.subsystems.drive.DriveSubsystem;
-import competition.subsystems.pose.PoseSubsystem;
-import competition.subsystems.vision.AprilTagVisionSubsystemExtended;
 import dagger.Binds;
 import dagger.Module;
-import xbot.common.injection.electrical_contract.XCameraElectricalContract;
-import xbot.common.injection.electrical_contract.XSwerveDriveElectricalContract;
-import xbot.common.subsystems.drive.BaseDriveSubsystem;
-import xbot.common.subsystems.drive.BaseSwerveDriveSubsystem;
-import xbot.common.subsystems.pose.BasePoseSubsystem;
-import xbot.common.subsystems.vision.AprilTagVisionSubsystem;
 
 import javax.inject.Singleton;
 

--- a/src/main/java/competition/injection/modules/Module2024.java
+++ b/src/main/java/competition/injection/modules/Module2024.java
@@ -4,17 +4,8 @@ import competition.electrical_contract.ElectricalContract;
 import competition.simulation.BaseSimulator;
 import competition.simulation.NoopSimulator;
 import competition.electrical_contract.Contract2024;
-import competition.subsystems.drive.DriveSubsystem;
-import competition.subsystems.pose.PoseSubsystem;
-import competition.subsystems.vision.AprilTagVisionSubsystemExtended;
 import dagger.Binds;
 import dagger.Module;
-import xbot.common.injection.electrical_contract.XCameraElectricalContract;
-import xbot.common.injection.electrical_contract.XSwerveDriveElectricalContract;
-import xbot.common.subsystems.drive.BaseDriveSubsystem;
-import xbot.common.subsystems.drive.BaseSwerveDriveSubsystem;
-import xbot.common.subsystems.pose.BasePoseSubsystem;
-import xbot.common.subsystems.vision.AprilTagVisionSubsystem;
 
 import javax.inject.Singleton;
 

--- a/src/main/java/competition/injection/modules/Module2025.java
+++ b/src/main/java/competition/injection/modules/Module2025.java
@@ -6,17 +6,8 @@ import competition.electrical_contract.Contract2025;
 import competition.electrical_contract.ElectricalContract;
 import competition.simulation.BaseSimulator;
 import competition.simulation.NoopSimulator;
-import competition.subsystems.drive.DriveSubsystem;
-import competition.subsystems.pose.PoseSubsystem;
-import competition.subsystems.vision.AprilTagVisionSubsystemExtended;
 import dagger.Binds;
 import dagger.Module;
-import xbot.common.injection.electrical_contract.XCameraElectricalContract;
-import xbot.common.injection.electrical_contract.XSwerveDriveElectricalContract;
-import xbot.common.subsystems.drive.BaseDriveSubsystem;
-import xbot.common.subsystems.drive.BaseSwerveDriveSubsystem;
-import xbot.common.subsystems.pose.BasePoseSubsystem;
-import xbot.common.subsystems.vision.AprilTagVisionSubsystem;
 
 @Module
 public abstract class Module2025 {

--- a/src/main/java/competition/injection/modules/RoboxModule.java
+++ b/src/main/java/competition/injection/modules/RoboxModule.java
@@ -4,17 +4,8 @@ import competition.electrical_contract.ElectricalContract;
 import competition.electrical_contract.RoboxContract;
 import competition.simulation.BaseSimulator;
 import competition.simulation.NoopSimulator;
-import competition.subsystems.drive.DriveSubsystem;
-import competition.subsystems.pose.PoseSubsystem;
-import competition.subsystems.vision.AprilTagVisionSubsystemExtended;
 import dagger.Binds;
 import dagger.Module;
-import xbot.common.injection.electrical_contract.XCameraElectricalContract;
-import xbot.common.injection.electrical_contract.XSwerveDriveElectricalContract;
-import xbot.common.subsystems.drive.BaseDriveSubsystem;
-import xbot.common.subsystems.drive.BaseSwerveDriveSubsystem;
-import xbot.common.subsystems.pose.BasePoseSubsystem;
-import xbot.common.subsystems.vision.AprilTagVisionSubsystem;
 
 import javax.inject.Singleton;
 

--- a/src/main/java/competition/injection/modules/SimulatedRobotModule.java
+++ b/src/main/java/competition/injection/modules/SimulatedRobotModule.java
@@ -2,22 +2,11 @@ package competition.injection.modules;
 
 import javax.inject.Singleton;
 
-import competition.electrical_contract.ElectricalContract;
-import competition.electrical_contract.UnitTestContract2025;
 import competition.simulation.BaseSimulator;
 import competition.simulation.MapleSimulator;
-import competition.subsystems.drive.DriveSubsystem;
-import competition.subsystems.pose.PoseSubsystem;
-import competition.subsystems.vision.AprilTagVisionSubsystemExtended;
 import dagger.Binds;
 import dagger.Module;
-import xbot.common.injection.electrical_contract.XCameraElectricalContract;
-import xbot.common.injection.electrical_contract.XSwerveDriveElectricalContract;
-import xbot.common.subsystems.drive.BaseDriveSubsystem;
-import xbot.common.subsystems.drive.BaseSwerveDriveSubsystem;
-import xbot.common.subsystems.pose.BasePoseSubsystem;
 import xbot.common.subsystems.pose.SimulatedPositionSupplier;
-import xbot.common.subsystems.vision.AprilTagVisionSubsystem;
 
 @Module
 public abstract class SimulatedRobotModule {

--- a/src/main/java/competition/injection/modules/UnitTestRobotModule.java
+++ b/src/main/java/competition/injection/modules/UnitTestRobotModule.java
@@ -1,20 +1,9 @@
 package competition.injection.modules;
 
-import competition.electrical_contract.ElectricalContract;
-import competition.electrical_contract.UnitTestContract2025;
 import competition.simulation.BaseSimulator;
 import competition.simulation.MapleSimulator;
-import competition.subsystems.drive.DriveSubsystem;
-import competition.subsystems.pose.PoseSubsystem;
-import competition.subsystems.vision.AprilTagVisionSubsystemExtended;
 import dagger.Binds;
 import dagger.Module;
-import xbot.common.injection.electrical_contract.XCameraElectricalContract;
-import xbot.common.injection.electrical_contract.XSwerveDriveElectricalContract;
-import xbot.common.subsystems.drive.BaseDriveSubsystem;
-import xbot.common.subsystems.drive.BaseSwerveDriveSubsystem;
-import xbot.common.subsystems.pose.BasePoseSubsystem;
-import xbot.common.subsystems.vision.AprilTagVisionSubsystem;
 
 import javax.inject.Singleton;
 

--- a/src/main/java/competition/operator_interface/OperatorCommandMap.java
+++ b/src/main/java/competition/operator_interface/OperatorCommandMap.java
@@ -140,12 +140,15 @@ public class OperatorCommandMap {
         oi.operatorGamepad.getifAvailable(XXboxController.XboxButton.LeftTrigger).whileTrue(intakeCoralCommand);
         oi.operatorGamepad.getifAvailable(XXboxController.XboxButton.RightTrigger).whileTrue(scoreCoralCommand);
 
-        // combine all three claibration commands into one parallal command group
-        var calibrateAll = Commands.parallel(
-                forceElevatorCalibratedCommand,
-                forceCoralPivotCalibratedCommand,
+        var calibrateAlgae = Commands.parallel(
                 forceAlgaeArmCalibrated).ignoringDisable(true);
-        oi.operatorGamepad.getifAvailable(XXboxController.XboxButton.Start).onTrue(calibrateAll);
+        var calibrateSuperstructure = Commands.parallel(
+                forceElevatorCalibratedCommand,
+                forceCoralPivotCalibratedCommand
+        ).ignoringDisable(true);
+
+        oi.operatorGamepad.getifAvailable(XXboxController.XboxButton.Start).onTrue(calibrateAlgae);
+        oi.operatorGamepad.getifAvailable(XXboxController.XboxButton.RightStick).onTrue(calibrateSuperstructure);
 
         // Algae system buttons
         var removeLowAlgae = prepAlgaeSystemCommandGroupFactory.create(AlgaeArmSubsystem.AlgaeArmPositions.ReefAlgaeLow);

--- a/src/main/java/competition/subsystems/algae_arm/AlgaeArmSubsystem.java
+++ b/src/main/java/competition/subsystems/algae_arm/AlgaeArmSubsystem.java
@@ -169,6 +169,7 @@ public class AlgaeArmSubsystem extends BaseSetpointSubsystem<Angle> {
     public void setPower(double power) {
         if (electricalContract.isAlgaeArmPivotMotorReady()) {
 
+            /*
             if (isCalibrated) {
                 double currentAngle = getCurrentValue().in(Degrees);
                 if (currentAngle < 0) {
@@ -181,7 +182,7 @@ public class AlgaeArmSubsystem extends BaseSetpointSubsystem<Angle> {
 
             if (isTouchingBottom()) {
                 power = MathUtils.constrainDouble(power, 0, 1);
-            }
+            }*/
 
             this.armMotor.setPower(power);
         }

--- a/src/main/java/competition/subsystems/coral_scorer/CoralScorerSubsystem.java
+++ b/src/main/java/competition/subsystems/coral_scorer/CoralScorerSubsystem.java
@@ -70,7 +70,7 @@ public class CoralScorerSubsystem extends BaseSubsystem implements CoralCollecti
         this.intakePower = propertyFactory.createPersistentProperty("intakePower", 0.3);
         this.hasCoralIntakePower = propertyFactory.createPersistentProperty("hasCoralIntakePower", 0.05);
         this.scorePower = propertyFactory.createPersistentProperty("scorerPower", -0.8);
-        this.waitTimeAfterScoring = propertyFactory.createPersistentProperty("waitTimeAfterScoring", 0.5);
+        this.waitTimeAfterScoring = propertyFactory.createPersistentProperty("waitTimeAfterScoring", 1);
         this.waitTimeAfterCollection = propertyFactory.createPersistentProperty("waitTimeAfterCollection", 0.1);
 
         this.intakeFreeSpeedRPSProperty = propertyFactory.createPersistentProperty("intakeFreeSpeedRPS", 3);

--- a/src/main/java/competition/subsystems/coral_scorer/CoralScorerSubsystem.java
+++ b/src/main/java/competition/subsystems/coral_scorer/CoralScorerSubsystem.java
@@ -70,7 +70,7 @@ public class CoralScorerSubsystem extends BaseSubsystem implements CoralCollecti
         this.intakePower = propertyFactory.createPersistentProperty("intakePower", 0.3);
         this.hasCoralIntakePower = propertyFactory.createPersistentProperty("hasCoralIntakePower", 0.05);
         this.scorePower = propertyFactory.createPersistentProperty("scorerPower", -0.8);
-        this.waitTimeAfterScoring = propertyFactory.createPersistentProperty("waitTimeAfterScoring", 1);
+        this.waitTimeAfterScoring = propertyFactory.createPersistentProperty("waitTimeAfterScoring", 0.2);
         this.waitTimeAfterCollection = propertyFactory.createPersistentProperty("waitTimeAfterCollection", 0.1);
 
         this.intakeFreeSpeedRPSProperty = propertyFactory.createPersistentProperty("intakeFreeSpeedRPS", 3);

--- a/src/main/java/competition/subsystems/drive/logic/AlignCameraToAprilTagCalculator.java
+++ b/src/main/java/competition/subsystems/drive/logic/AlignCameraToAprilTagCalculator.java
@@ -45,7 +45,9 @@ public class AlignCameraToAprilTagCalculator {
         ApproachWhileCentering,
         TerminalApproach,
         Shove,
-        Complete
+        Complete,
+        GaveUp,
+        TerminalApproachWithoutVision
     }
 
     public enum ApproachMode {
@@ -74,7 +76,8 @@ public class AlignCameraToAprilTagCalculator {
     Translation2d targetLocationOnField = new Translation2d(0, 0);
 
     final DoubleProperty interstitialDistance;
-    final DoubleProperty distanceFromInterstitialToAdvance;
+    final DoubleProperty distanceFromInterstitialToAdvanceFast;
+    final DoubleProperty distanceFromInterstitialToAdvanceSlow;
     final DoubleProperty approachSpeedFactor;
     final DoubleProperty distanceToStartShoving;
     final DoubleProperty shovePower;
@@ -86,7 +89,7 @@ public class AlignCameraToAprilTagCalculator {
     final DoubleProperty closeApproachSpeedFactor;
     final DoubleProperty closeInterstitialActivationRange;
 
-    double lastKnownHorizontalErrorMeters = 0;
+    double lastKnownHorizontalErrorMeters = 999999;
     double shoveStartTime = 0;
     private Activity startingActivity = Activity.Searching;
     private boolean requireExcellentAlignment = true;
@@ -96,6 +99,10 @@ public class AlignCameraToAprilTagCalculator {
     double idealFinalHeadingDegrees;
     Pose2d interstitialPoint;
     private ApproachMode approachMode;
+
+    private boolean hasEverSeenAprilTag = false;
+    private Translation2d coralStationPreShovePoint;
+    boolean retryActive;
 
     public static Translation2d generateAlignmentPointOffset(Distance robotCenterToOuterBumperX, CameraInfo cameraInfo,
                                                              Distance offset, boolean isCameraBackwards) {
@@ -130,7 +137,8 @@ public class AlignCameraToAprilTagCalculator {
 
         pf.setPrefix(prefix);
         interstitialDistance = pf.createPersistentProperty("InterstitialDistance-m", 2.25);
-        distanceFromInterstitialToAdvance = pf.createPersistentProperty("DistanceFromInterstitialToAdvance-m", 0.2);
+        distanceFromInterstitialToAdvanceFast = pf.createPersistentProperty("DistanceFromInterstitialToAdvanceFast-m", 0.4);
+        distanceFromInterstitialToAdvanceSlow = pf.createPersistentProperty("DistanceFromInterstitialToAdvanceSlow-m", 0.2);
         approachSpeedFactor = pf.createPersistentProperty("ApproachSpeedFactor", 0.65);
         distanceToStartShoving = pf.createPersistentProperty("DistanceToStartShoving-m", 0.0762); // 3 inches
         shovePower = pf.createPersistentProperty("ShovePower", 0.25);
@@ -246,6 +254,7 @@ public class AlignCameraToAprilTagCalculator {
         // Mostly, this is about where we should be pointing - and we generally point at the tag unless we are fairly close.
         Optional<AprilTagVisionIO.TargetObservation> targetObservation = aprilTagVisionSubsystem.getTargetObservation(targetCameraID, targetAprilTagID);
         boolean doWeSeeOurTargetTag = targetObservation.isPresent() && targetObservation.get().ambiguity() < maxTagAmbiguity.get();
+        hasEverSeenAprilTag |= doWeSeeOurTargetTag;
 
         Translation2d currentTranslation = pose.getCurrentPose2d().getTranslation();
         double headingToPointAtAprilTag = Radians.of(
@@ -300,8 +309,21 @@ public class AlignCameraToAprilTagCalculator {
                 rotationIntent = headingModule.calculateHeadingPower(headingToPointAtAprilTag);
 
                 // Finally, a check to see if we're quite close and should advance to the next state.
-                if (currentPose.getTranslation().getDistance(interstitialPoint.getTranslation()) < distanceFromInterstitialToAdvance.get()) {
+
+                var distanceThresholdToAdvance = distanceFromInterstitialToAdvanceFast.get();
+                if (approachMode == ApproachMode.Close) {
+                    distanceThresholdToAdvance = distanceFromInterstitialToAdvanceSlow.get();
+                }
+
+                if (currentPose.getTranslation().getDistance(interstitialPoint.getTranslation()) < distanceThresholdToAdvance) {
                     activity = Activity.TerminalApproach;
+
+                    if (!hasEverSeenAprilTag && isCameraBackwards) {
+                        // We failed to find a tag. Try just using classic global pose
+                        activity = Activity.TerminalApproachWithoutVision;
+                        coralStationPreShovePoint = getCoralStationPreShovePoint();
+                        pose.setPreferOdometryToVision(false);
+                    }
                 }
                 break;
             case TerminalApproach:
@@ -341,6 +363,19 @@ public class AlignCameraToAprilTagCalculator {
                     }
                 }
                 break;
+            case TerminalApproachWithoutVision:
+                var noVisionPower = drive.getPowerToAchieveFieldPosition(currentPose.getTranslation(), coralStationPreShovePoint);
+                // If we are going too fast, cap the speed.
+                if (noVisionPower.getNorm() >  approachSpeedFactor) {
+                    powers = new Translation2d(approachSpeedFactor, noVisionPower.getAngle());
+                }
+                driveIntent = new XYPair(noVisionPower.getX(), noVisionPower.getY()).scale(approachSpeedFactor);
+                rotationIntent = headingModule.calculateHeadingPower(idealFinalHeadingDegrees);
+                if (currentPose.getTranslation().getDistance(coralStationPreShovePoint) < distanceToStartShoving.get()) {
+                    activity = Activity.Shove;
+                    shoveStartTime = XTimer.getFPGATimestamp();
+                }
+                break;
             case Shove:
                 // We are so very close to our destination, but it's very hard to get perfect alignment -- the PID
                 // will bring us close, but error in the dive might mean we are off by a few inches. We are also
@@ -364,6 +399,7 @@ public class AlignCameraToAprilTagCalculator {
                 }
                 break;
             case Complete:
+            case GaveUp:
             default:
                 // We're done! We don't need to do anything.
                 break;
@@ -416,6 +452,15 @@ public class AlignCameraToAprilTagCalculator {
     }
 
     public boolean recommendIsFinished() {
-        return activity == Activity.Complete;
+        return activity == Activity.Complete || activity == Activity.GaveUp;
+    }
+
+    private Translation2d getCoralStationPreShovePoint() {
+        var station = Landmarks.getCoralStationFromTagId(targetAprilTagID);
+        var stationLocation = PoseSubsystem.convertBlueToRedIfNeeded(
+                Landmarks.getCoralStationSectionPose(station, Landmarks.CoralStationSection.MID));
+
+        var projectedDelta = new Translation2d(0.25, stationLocation.getRotation());
+        return stationLocation.getTranslation().plus(projectedDelta);
     }
 }

--- a/src/main/java/competition/subsystems/pose/PoseSubsystem.java
+++ b/src/main/java/competition/subsystems/pose/PoseSubsystem.java
@@ -9,6 +9,7 @@ import java.util.function.Supplier;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import competition.electrical_contract.ElectricalContract;
 import competition.subsystems.drive.DriveSubsystem;
 import competition.subsystems.vision.AprilTagVisionSubsystemExtended;
 import competition.subsystems.vision.CoprocessorCommunicationSubsystem;
@@ -26,6 +27,7 @@ import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import org.kobe.xbot.JClient.XTablesClient;
 import org.kobe.xbot.Utilities.Entities.BatchedPushRequests;
+import xbot.common.controls.sensors.XGyro;
 import xbot.common.controls.sensors.XGyro.XGyroFactory;
 import xbot.common.math.WrappedRotation2d;
 import xbot.common.properties.BooleanProperty;
@@ -45,6 +47,8 @@ public class PoseSubsystem extends BasePoseSubsystem {
     private final BooleanProperty reportCameraPoses;
     private final CoprocessorCommunicationSubsystem coprocessorComms;
 
+    private final XGyro pigeon2Gyro;
+
     public static final Distance fieldXMidpointInMeters = Meters.of(8.7785);
     public static final Distance fieldYMidpointInMeters = Meters.of(4.025);
 
@@ -55,12 +59,16 @@ public class PoseSubsystem extends BasePoseSubsystem {
     protected Optional<SwerveModulePosition[]> simulatedModulePositions = Optional.empty();
 
     @Inject
-    public PoseSubsystem(XGyroFactory gyroFactory, PropertyFactory propManager, DriveSubsystem drive,
-                         AprilTagVisionSubsystemExtended aprilTagVisionSubsystem, CoprocessorCommunicationSubsystem coprocessorComms) {
-        super(gyroFactory, propManager);
+    public PoseSubsystem(XGyroFactory gyroFactory,
+                         ElectricalContract electricalContract,
+                         PropertyFactory propManager, DriveSubsystem drive,
+                         AprilTagVisionSubsystemExtended aprilTagVisionSubsystem,
+                         CoprocessorCommunicationSubsystem coprocessorComms) {
+        super(gyroFactory.create(electricalContract.getNavXGyroInfo()), propManager);
         this.drive = drive;
         this.aprilTagVisionSubsystem = aprilTagVisionSubsystem;
         this.coprocessorComms = coprocessorComms;
+        this.pigeon2Gyro = gyroFactory.create(electricalContract.getPigeon2GyroInfo());
 
         onlyWheelsGyroSwerveOdometry = initializeSwerveOdometry();
         fullSwerveOdometry = initializeSwerveOdometry();
@@ -69,6 +77,12 @@ public class PoseSubsystem extends BasePoseSubsystem {
         propManager.setDefaultLevel(Property.PropertyLevel.Important);
         useVisionAssistedPose = propManager.createPersistentProperty("UseVisionAssistedPose", true);
         reportCameraPoses = propManager.createPersistentProperty("ReportCameraPoses", false);
+    }
+
+    @Override
+    public void refreshDataFrame() {
+        super.refreshDataFrame();
+        pigeon2Gyro.refreshDataFrame();
     }
 
     @Override


### PR DESCRIPTION
# Why are we doing this?
This is all the changes from Sammamish Day 1.
Asana task URL:

# Whats changing?
- Adds a 0.8 second wait before scoring in auto to allow the superstructure to stop wobbling before we try and score
- Adds the Pigeon as a gyro (though only for logging so far)
- Splits calibration into two commands - one for algae arm, one for elevator/stinger
- Removes all safeties on the algae arm since the chain skips so much
- Adds a "emergency backup point" when driving to the coral station in case we never see the AprilTag even once
- Allows for a larger "Advance to next stage range" in the AprilTagCalculator when driving fast
- 
# Questions/notes for reviewers

# How this was tested
- [x] tested on robot
- [ ] tested in simulator
- [ ] unit tests added

## Video/screenshots (from simulator or live robot)

-----

PR feedback legend

 
| Symbol | Meaning                  |
|--------|--------------------------|
| :star: :star: :star:     | must be addressed                 |
| :star: :star:     | should be addressed        |
| :star:     | something to consider, a good idea                  |
