### PR TITLE
Parallelize parts of auto setup to reduce time to movement start

### DIFF
--- a/src/main/java/competition/auto_programs/BaseAutonomousSequentialCommandGroup.java
+++ b/src/main/java/competition/auto_programs/BaseAutonomousSequentialCommandGroup.java
@@ -1,6 +1,7 @@
 package competition.auto_programs;
 
 import competition.subsystems.pose.Landmarks;
+import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import xbot.common.subsystems.autonomous.AutonomousCommandSelector;
 
@@ -12,21 +13,21 @@ public class BaseAutonomousSequentialCommandGroup extends SequentialCommandGroup
         this.autoSelector = autoSelector;
     }
 
-    public void queueMessageToAutoSelector(String message) {
-        this.addCommands(autoSelector.createAutonomousStateMessageCommand(message));
+    public Command getAutoStatusChangeCommand(String message) {
+        return autoSelector.createAutonomousStateMessageCommand(message);
     }
 
-    public void queueDriveAndScoreMessageToAutoSelector(Landmarks.ReefFace targetReefFace,
+    public Command getDriveAndScoreStatusMessageCommand(Landmarks.ReefFace targetReefFace,
                                                         Landmarks.Branch targetBranch,
                                                         Landmarks.CoralLevel targetLevel) {
         String message = "Drive to " + targetReefFace + ", Branch " + targetBranch + ", and score" + targetLevel;
-        queueMessageToAutoSelector(message);
+        return getAutoStatusChangeCommand(message);
     }
 
-    public void queueDriveAndIntakeMessageToAutoSelector(Landmarks.CoralStation targetStation,
+    public Command getDriveAndIntakeStatusMessageCommand(Landmarks.CoralStation targetStation,
                                                          Landmarks.CoralStationSection targetSection) {
         String message = "Drive to " + targetStation + " coral station, " + targetSection + " section and intake coral until collected";
-        queueMessageToAutoSelector(message);
+        return getAutoStatusChangeCommand(message);
     }
 
 }

--- a/src/main/java/competition/auto_programs/FromCageScoreOneCoralAutoFactory.java
+++ b/src/main/java/competition/auto_programs/FromCageScoreOneCoralAutoFactory.java
@@ -3,16 +3,13 @@ package competition.auto_programs;
 import competition.commandgroups.DriveToFaceAndScoreCommandGroupFactory;
 import competition.commandgroups.PrepCoralSystemCommandGroupFactory;
 import competition.simulation.BaseSimulator;
-import competition.simulation.MapleSimulator;
 import competition.subsystems.pose.Landmarks;
 import competition.subsystems.pose.PoseSubsystem;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
-import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import xbot.common.subsystems.autonomous.AutonomousCommandSelector;
 
 import javax.inject.Inject;
-import javax.inject.Provider;
 
 public class FromCageScoreOneCoralAutoFactory {
 
@@ -27,7 +24,7 @@ public class FromCageScoreOneCoralAutoFactory {
                                             BaseSimulator simulator,
                                             PoseSubsystem pose,
                                             DriveToFaceAndScoreCommandGroupFactory driveToFaceAndScoreCommandGroupFact,
-                                            PrepCoralSystemCommandGroupFactory prepCoralSystemCommandGroupFact){
+                                            PrepCoralSystemCommandGroupFactory prepCoralSystemCommandGroupFact) {
         this.autoSelector = autoSelector;
         this.simulator = simulator;
         this.pose = pose;
@@ -36,18 +33,19 @@ public class FromCageScoreOneCoralAutoFactory {
     }
 
     public BaseAutonomousSequentialCommandGroup create(Pose2d startingLocation,
-                                         Landmarks.ReefFace targetReefFace, Landmarks.Branch targetBranch,
-                                         Landmarks.CoralLevel targetLevel) {
+                                                       Landmarks.ReefFace targetReefFace, Landmarks.Branch targetBranch,
+                                                       Landmarks.CoralLevel targetLevel) {
         var auto = new BaseAutonomousSequentialCommandGroup(autoSelector);
 
-        var startInFrontOfCage = pose.createSetPositionCommand(PoseSubsystem.convertBlueToRedIfNeeded(startingLocation));
-        auto.addCommands(startInFrontOfCage);
+        var initializeStateCommand = pose.createSetPositionCommand(
+                        () -> PoseSubsystem.convertBlueToRedIfNeeded(startingLocation)
+                )
+                .alongWith(new InstantCommand(() -> simulator.resetPosition(PoseSubsystem.convertBlueToRedIfNeeded(startingLocation))));
+        auto.addCommands(initializeStateCommand);
 
-        var resetSim = new InstantCommand(() -> simulator.resetPosition(PoseSubsystem.convertBlueToRedIfNeeded(startingLocation)));
-        auto.addCommands(resetSim);
-
-        auto.queueDriveAndScoreMessageToAutoSelector(targetReefFace, targetBranch, targetLevel);
-        var driveAndScore = driveToFaceAndScoreCommandGroupFact.create(targetReefFace, targetBranch, targetLevel);
+        var driveAndScore = driveToFaceAndScoreCommandGroupFact.create(targetReefFace, targetBranch, targetLevel)
+                .alongWith(
+                        auto.getDriveAndScoreStatusMessageCommand(targetReefFace, targetBranch, targetLevel));
         auto.addCommands(driveAndScore);
 
         var homeCoralSystem = prepCoralSystemCommandGroupFact.create(() -> Landmarks.CoralLevel.COLLECTING);
@@ -55,6 +53,4 @@ public class FromCageScoreOneCoralAutoFactory {
 
         return auto;
     }
-
-
 }

--- a/src/main/java/competition/auto_programs/FromLeftCageScoreLeftFacesLevelFours.java
+++ b/src/main/java/competition/auto_programs/FromLeftCageScoreLeftFacesLevelFours.java
@@ -4,14 +4,12 @@ import competition.commandgroups.DriveToFaceAndScoreCommandGroupFactory;
 import competition.commandgroups.DriveToStationAndIntakeUntilCollectedCommandGroupFactory;
 import competition.commandgroups.PrepCoralSystemCommandGroupFactory;
 import competition.simulation.BaseSimulator;
-import competition.simulation.MapleSimulator;
 import competition.subsystems.pose.Landmarks;
 import competition.subsystems.pose.PoseSubsystem;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import xbot.common.subsystems.autonomous.AutonomousCommandSelector;
 
 import javax.inject.Inject;
-import javax.inject.Provider;
 
 public class FromLeftCageScoreLeftFacesLevelFours extends BaseAutonomousSequentialCommandGroup {
 
@@ -25,54 +23,56 @@ public class FromLeftCageScoreLeftFacesLevelFours extends BaseAutonomousSequenti
         super(autoSelector);
 
         // Force our location to start in front of cage one
-        var startInFrontOfCageOne = pose.createSetPositionCommand(
-                () -> PoseSubsystem.convertBlueToRedIfNeeded(Landmarks.BlueCageOneStartingLine)
-        );
-        this.addCommands(startInFrontOfCageOne);
-
-        var resetSim = new InstantCommand(() -> simulator.resetPosition(PoseSubsystem.convertBlueToRedIfNeeded(Landmarks.BlueCageOneStartingLine)));
-        this.addCommands(resetSim);
+        var initializeStateCommand = pose.createSetPositionCommand(
+                        () -> PoseSubsystem.convertBlueToRedIfNeeded(Landmarks.BlueCageOneStartingLine)
+                )
+                .alongWith(new InstantCommand(() -> simulator.resetPosition(PoseSubsystem.convertBlueToRedIfNeeded(Landmarks.BlueCageOneStartingLine))));
+        this.addCommands(initializeStateCommand);
 
         // Drive to far left, branch B and score level four
-        queueDriveAndScoreMessageToAutoSelector(Landmarks.ReefFace.FAR_LEFT, Landmarks.Branch.B, Landmarks.CoralLevel.FOUR);
+        getDriveAndScoreStatusMessageCommand(Landmarks.ReefFace.FAR_LEFT, Landmarks.Branch.B, Landmarks.CoralLevel.FOUR);
         var driveAndScoreFarLeftBranchBLevelFour = driveToFaceAndScoreFact.create(
-                Landmarks.ReefFace.FAR_LEFT, Landmarks.Branch.B, Landmarks.CoralLevel.FOUR);
+                        Landmarks.ReefFace.FAR_LEFT, Landmarks.Branch.B, Landmarks.CoralLevel.FOUR)
+                .alongWith(getDriveAndScoreStatusMessageCommand(Landmarks.ReefFace.FAR_LEFT, Landmarks.Branch.B, Landmarks.CoralLevel.FOUR));
         this.addCommands(driveAndScoreFarLeftBranchBLevelFour);
 
         // Drive to left coral station and intake coral until collected
-        queueDriveAndIntakeMessageToAutoSelector(Landmarks.CoralStation.LEFT, Landmarks.CoralStationSection.MID);
         var driveToLeftStationAndIntakeFirst = driveToStationAndIntakeFact.create(
-                Landmarks.CoralStation.LEFT, true);
+                        Landmarks.CoralStation.LEFT, true)
+                .alongWith(getDriveAndIntakeStatusMessageCommand(Landmarks.CoralStation.LEFT, Landmarks.CoralStationSection.MID));
         this.addCommands(driveToLeftStationAndIntakeFirst);
 
         // Drive to close left, branch B and score level four
-        queueDriveAndScoreMessageToAutoSelector(Landmarks.ReefFace.CLOSE_LEFT, Landmarks.Branch.B, Landmarks.CoralLevel.FOUR);
         var driveAndScoreCloseLeftBranchBLevelFour = driveToFaceAndScoreFact.create(
-                Landmarks.ReefFace.CLOSE_LEFT, Landmarks.Branch.B, Landmarks.CoralLevel.FOUR);
+                        Landmarks.ReefFace.CLOSE_LEFT, Landmarks.Branch.B, Landmarks.CoralLevel.FOUR)
+                .alongWith(getDriveAndScoreStatusMessageCommand(Landmarks.ReefFace.CLOSE_LEFT, Landmarks.Branch.B, Landmarks.CoralLevel.FOUR));
         this.addCommands(driveAndScoreCloseLeftBranchBLevelFour);
 
         // Drive to left coral station and intake coral until collected
-        queueDriveAndIntakeMessageToAutoSelector(Landmarks.CoralStation.LEFT, Landmarks.CoralStationSection.MID);
         var driveToLeftStationAndIntakeSecond = driveToStationAndIntakeFact.create(
-                Landmarks.CoralStation.LEFT, false);
+                        Landmarks.CoralStation.LEFT, false)
+                .alongWith(getDriveAndIntakeStatusMessageCommand(Landmarks.CoralStation.LEFT, Landmarks.CoralStationSection.MID));
         this.addCommands(driveToLeftStationAndIntakeSecond);
 
         // Drive to close left, branch A and score level four
-        queueDriveAndScoreMessageToAutoSelector(Landmarks.ReefFace.CLOSE_LEFT, Landmarks.Branch.A, Landmarks.CoralLevel.FOUR);
         var driveAndScoreCloseLeftBranchALevelFour = driveToFaceAndScoreFact.create(
-                Landmarks.ReefFace.CLOSE_LEFT, Landmarks.Branch.A, Landmarks.CoralLevel.FOUR);
+                        Landmarks.ReefFace.CLOSE_LEFT, Landmarks.Branch.A, Landmarks.CoralLevel.FOUR)
+                .alongWith(
+                        getDriveAndScoreStatusMessageCommand(Landmarks.ReefFace.CLOSE_LEFT, Landmarks.Branch.A, Landmarks.CoralLevel.FOUR));
         this.addCommands(driveAndScoreCloseLeftBranchALevelFour);
 
         // Drive to left coral station and intake coral until collected
-        queueDriveAndIntakeMessageToAutoSelector(Landmarks.CoralStation.LEFT, Landmarks.CoralStationSection.MID);
         var driveToLeftStationAndIntakeThird = driveToStationAndIntakeFact.create(
-                Landmarks.CoralStation.LEFT, false);
+                        Landmarks.CoralStation.LEFT, false)
+                .alongWith(
+                        getDriveAndIntakeStatusMessageCommand(Landmarks.CoralStation.LEFT, Landmarks.CoralStationSection.MID));
         this.addCommands(driveToLeftStationAndIntakeThird);
 
         // Drive to close, branch A and score level four
-        queueDriveAndScoreMessageToAutoSelector(Landmarks.ReefFace.CLOSE, Landmarks.Branch.A, Landmarks.CoralLevel.FOUR);
         var driveAndScoreCloseBranchALevelFour = driveToFaceAndScoreFact.create(
-                Landmarks.ReefFace.CLOSE, Landmarks.Branch.A, Landmarks.CoralLevel.FOUR);
+                        Landmarks.ReefFace.CLOSE, Landmarks.Branch.A, Landmarks.CoralLevel.FOUR)
+                .alongWith(
+                        getDriveAndScoreStatusMessageCommand(Landmarks.ReefFace.CLOSE, Landmarks.Branch.A, Landmarks.CoralLevel.FOUR));
         this.addCommands(driveAndScoreCloseBranchALevelFour);
 
         // TODO: replace this with drive and intake commandgroup instead

--- a/src/main/java/competition/auto_programs/FromRightCageScoreRightFacesLevelFours.java
+++ b/src/main/java/competition/auto_programs/FromRightCageScoreRightFacesLevelFours.java
@@ -4,7 +4,6 @@ import competition.commandgroups.DriveToFaceAndScoreCommandGroupFactory;
 import competition.commandgroups.DriveToStationAndIntakeUntilCollectedCommandGroupFactory;
 import competition.commandgroups.PrepCoralSystemCommandGroupFactory;
 import competition.simulation.BaseSimulator;
-import competition.simulation.MapleSimulator;
 import competition.subsystems.pose.Landmarks;
 import competition.subsystems.pose.PoseSubsystem;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
@@ -17,62 +16,66 @@ public class FromRightCageScoreRightFacesLevelFours extends BaseAutonomousSequen
 
     @Inject
     public FromRightCageScoreRightFacesLevelFours(AutonomousCommandSelector autoSelector,
-                                                 PoseSubsystem pose,
-                                                 Provider<DriveToFaceAndScoreCommandGroupFactory> driveToFaceAndScoreFactProv,
-                                                 Provider<DriveToStationAndIntakeUntilCollectedCommandGroupFactory> driveToStationAndIntakeFactProv,
-                                                 PrepCoralSystemCommandGroupFactory prepCoralSystemCommandGroupFact,
-                                                 BaseSimulator simulator) {
+                                                  PoseSubsystem pose,
+                                                  Provider<DriveToFaceAndScoreCommandGroupFactory> driveToFaceAndScoreFactProv,
+                                                  Provider<DriveToStationAndIntakeUntilCollectedCommandGroupFactory> driveToStationAndIntakeFactProv,
+                                                  PrepCoralSystemCommandGroupFactory prepCoralSystemCommandGroupFact,
+                                                  BaseSimulator simulator) {
         super(autoSelector);
 
         // Force our location to start in front of cage six
-        var startInFrontOfCageSix = pose.createSetPositionCommand(
-                () -> PoseSubsystem.convertBlueToRedIfNeeded(Landmarks.BlueCageSixStartingLine)
-        );
-        this.addCommands(startInFrontOfCageSix);
-
-        var resetSim = new InstantCommand(() -> simulator.resetPosition(PoseSubsystem.convertBlueToRedIfNeeded(Landmarks.BlueCageSixStartingLine)));
-        this.addCommands(resetSim);
+        var initializeStateCommand = pose.createSetPositionCommand(
+                        () -> PoseSubsystem.convertBlueToRedIfNeeded(Landmarks.BlueCageSixStartingLine)
+                )
+                .alongWith(new InstantCommand(() -> simulator.resetPosition(PoseSubsystem.convertBlueToRedIfNeeded(Landmarks.BlueCageSixStartingLine))));
+        this.addCommands(initializeStateCommand);
 
         // Drive to far Right, branch B and score level four
-        queueDriveAndScoreMessageToAutoSelector(Landmarks.ReefFace.FAR_RIGHT, Landmarks.Branch.A, Landmarks.CoralLevel.FOUR);
         var driveAndScoreFarRightBranchBLevelFour = driveToFaceAndScoreFactProv.get().create(
-                Landmarks.ReefFace.FAR_RIGHT, Landmarks.Branch.A, Landmarks.CoralLevel.FOUR);
+                        Landmarks.ReefFace.FAR_RIGHT, Landmarks.Branch.A, Landmarks.CoralLevel.FOUR)
+                .alongWith(getDriveAndScoreStatusMessageCommand(Landmarks.ReefFace.FAR_RIGHT, Landmarks.Branch.A, Landmarks.CoralLevel.FOUR));
         this.addCommands(driveAndScoreFarRightBranchBLevelFour);
 
         // Drive to right coral station, far section and intake coral until collected
-        queueDriveAndIntakeMessageToAutoSelector(Landmarks.CoralStation.RIGHT, Landmarks.CoralStationSection.MID);
         var driveToRightStationAndIntakeFirst = driveToStationAndIntakeFactProv.get().create(
-                Landmarks.CoralStation.RIGHT, true);
+                        Landmarks.CoralStation.RIGHT, true)
+                .alongWith(
+                        getDriveAndIntakeStatusMessageCommand(Landmarks.CoralStation.RIGHT, Landmarks.CoralStationSection.MID));
         this.addCommands(driveToRightStationAndIntakeFirst);
 
         // Drive to close right, branch B and score level four
-        queueDriveAndScoreMessageToAutoSelector(Landmarks.ReefFace.CLOSE_RIGHT, Landmarks.Branch.A, Landmarks.CoralLevel.FOUR);
         var driveAndScoreCloseRightBranchBLevelFour = driveToFaceAndScoreFactProv.get().create(
-                Landmarks.ReefFace.CLOSE_RIGHT, Landmarks.Branch.A, Landmarks.CoralLevel.FOUR);
+                        Landmarks.ReefFace.CLOSE_RIGHT, Landmarks.Branch.A, Landmarks.CoralLevel.FOUR)
+                .alongWith(
+                        getDriveAndScoreStatusMessageCommand(Landmarks.ReefFace.CLOSE_RIGHT, Landmarks.Branch.A, Landmarks.CoralLevel.FOUR));
         this.addCommands(driveAndScoreCloseRightBranchBLevelFour);
 
         // Drive to right coral station, close section and intake coral until collected
-        queueDriveAndIntakeMessageToAutoSelector(Landmarks.CoralStation.RIGHT, Landmarks.CoralStationSection.MID);
         var driveToRightStationAndIntakeSecond = driveToStationAndIntakeFactProv.get().create(
-                Landmarks.CoralStation.RIGHT, false);
+                        Landmarks.CoralStation.RIGHT, false)
+                .alongWith(
+                        getDriveAndIntakeStatusMessageCommand(Landmarks.CoralStation.RIGHT, Landmarks.CoralStationSection.MID));
         this.addCommands(driveToRightStationAndIntakeSecond);
 
         // Drive to close right, branch A and score level four
-        queueDriveAndScoreMessageToAutoSelector(Landmarks.ReefFace.CLOSE_RIGHT, Landmarks.Branch.B, Landmarks.CoralLevel.FOUR);
         var driveAndScoreCloseRightBranchALevelFour = driveToFaceAndScoreFactProv.get().create(
-                Landmarks.ReefFace.CLOSE_RIGHT, Landmarks.Branch.B, Landmarks.CoralLevel.FOUR);
+                        Landmarks.ReefFace.CLOSE_RIGHT, Landmarks.Branch.B, Landmarks.CoralLevel.FOUR)
+                .alongWith(
+                        getDriveAndScoreStatusMessageCommand(Landmarks.ReefFace.CLOSE_RIGHT, Landmarks.Branch.B, Landmarks.CoralLevel.FOUR));
         this.addCommands(driveAndScoreCloseRightBranchALevelFour);
 
         // Drive to right coral station, far section and intake coral until collected again
-        queueDriveAndIntakeMessageToAutoSelector(Landmarks.CoralStation.RIGHT, Landmarks.CoralStationSection.MID);
         var driveToRightStationAndIntakeThird = driveToStationAndIntakeFactProv.get().create(
-                Landmarks.CoralStation.RIGHT, false);
+                        Landmarks.CoralStation.RIGHT, false)
+                .alongWith(
+                        getDriveAndIntakeStatusMessageCommand(Landmarks.CoralStation.RIGHT, Landmarks.CoralStationSection.MID));
         this.addCommands(driveToRightStationAndIntakeThird);
 
         // Drive to close, branch A and score level four
-        queueDriveAndScoreMessageToAutoSelector(Landmarks.ReefFace.CLOSE, Landmarks.Branch.B, Landmarks.CoralLevel.FOUR);
         var driveAndScoreCloseBranchALevelFour = driveToFaceAndScoreFactProv.get().create(
-                Landmarks.ReefFace.CLOSE, Landmarks.Branch.B, Landmarks.CoralLevel.FOUR);
+                        Landmarks.ReefFace.CLOSE, Landmarks.Branch.B, Landmarks.CoralLevel.FOUR)
+                .alongWith(
+                        getDriveAndScoreStatusMessageCommand(Landmarks.ReefFace.CLOSE, Landmarks.Branch.B, Landmarks.CoralLevel.FOUR));
         this.addCommands(driveAndScoreCloseBranchALevelFour);
 
         // TODO: replace this with drive and intake commandgroup instead


### PR DESCRIPTION
# Why are we doing this?
Our auto doesn't do anything visible for the first few cycles. Parallelize several steps to start acting faster.

# Whats changing?
Moved some init and logging steps to be run in parallel

# Questions/notes for reviewers

# How this was tested
- [ ] tested on robot
- [x] tested in simulator
- [ ] unit tests added

## Video/screenshots (from simulator or live robot)

-----

PR feedback legend

 
| Symbol | Meaning                  |
|--------|--------------------------|
| :star: :star: :star:     | must be addressed                 |
| :star: :star:     | should be addressed        |
| :star:     | something to consider, a good idea                  |
