### PR TITLE
Fix reef sim red side not rendering correctly

### DIFF
--- a/src/main/java/competition/simulation/reef/ReefSimulator.java
+++ b/src/main/java/competition/simulation/reef/ReefSimulator.java
@@ -139,23 +139,7 @@ public class ReefSimulator {
 
     public Pose3d[] getCoralPoses() {
         return reefCoralLocations.stream()
-                .map(coralLocation -> {
-                    Pose3d originalPose = getCoralPose(coralLocation.alliance, coralLocation.face(), coralLocation.level(), coralLocation.post());
-                    Pose2d pose  = originalPose.toPose2d();
-                    Rotation3d desiredRotation = originalPose.getRotation();
-
-                    // Flip stuff if red
-                    if (coralLocation.alliance() == Alliance.RED) {
-                        pose = PoseSubsystem.convertBluetoRed(pose);
-                        desiredRotation = new Rotation3d(
-                                desiredRotation.getX(),
-                                2 * Math.PI - desiredRotation.getY(),
-                                desiredRotation.getZ()
-                        );
-                    }
-
-                    return new Pose3d(pose.getX(), pose.getY(), originalPose.getZ(), desiredRotation);
-                })
+                .map(this::getCoralPose)
                 .toArray(Pose3d[]::new);
     }
 


### PR DESCRIPTION
# Why are we doing this?

There was a bug in the logic to display the reef on red, it would render the coral on blue still even though it knew it was red.

Asana task URL:

# Whats changing?

# Questions/notes for reviewers

# How this was tested
- [ ] tested on robot
- [ ] tested in simulator
- [ ] unit tests added

## Video/screenshots (from simulator or live robot)

-----

PR feedback legend

 
| Symbol | Meaning                  |
|--------|--------------------------|
| :star: :star: :star:     | must be addressed                 |
| :star: :star:     | should be addressed        |
| :star:     | something to consider, a good idea                  |
