### PR TITLE
Add more specific code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,4 +16,4 @@ src/main/java/competition/subsystems/coral_scorer/ @Glowdisk @AlanYuan99 @Team48
 
 src/main/java/competition/subsystems/drive/ @Rongrrz @Team488/core-robot-maintainers
 
-src/main/java/competition/auto_programs @anthonytrenh @Team488/core-robot-maintainers
+src/main/java/competition/auto_programs/ @anthonytrenh @Team488/core-robot-maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,19 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
 *       @Team488/core-robot-maintainers
+# Drive team should okay changes to button mappings
+src/main/java/competition/operator_interface/OperatorCommandMap.java @kujo27 @anthonytrenh @Team488/core-robot-maintainers
+
+src/main/java/competition/subsystems/elevator/ @junyu101 @Team488/core-robot-maintainers
+
+src/main/java/competition/subsystems/coral_arm/ @AlanYuan99 @Team488/core-robot-maintainers
+
+src/main/java/competition/subsystems/lights/ @AlanYuan99 @Team488/core-robot-maintainers
+
+src/main/java/competition/subsystems/algae_arm/ @Glowdisk @Team488/core-robot-maintainers
+
+src/main/java/competition/subsystems/coral_scorer/ @Glowdisk @AlanYuan99 @Team488/core-robot-maintainers
+
+src/main/java/competition/subsystems/drive/ @Rongrrz @Team488/core-robot-maintainers
+
+src/main/java/competition/auto_programs @anthonytrenh @Team488/core-robot-maintainers


### PR DESCRIPTION
# Why are we doing this?

Almost all the key areas of the code have a student that primarily worked on it. This will assign them formally as code owners so they'll get added on relevant PRs automatically.

Asana task URL:

# Whats changing?

# Questions/notes for reviewers

# How this was tested
- [ ] tested on robot
- [ ] tested in simulator
- [ ] unit tests added

## Video/screenshots (from simulator or live robot)

-----

PR feedback legend

 
| Symbol | Meaning                  |
|--------|--------------------------|
| :star: :star: :star:     | must be addressed                 |
| :star: :star:     | should be addressed        |
| :star:     | something to consider, a good idea                  |
