### PR TITLE
More tracing capability to cover commands defined in SCL and WPILib

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,12 +102,19 @@ repositories {
    }
 }
 
+configurations {
+    customAspectJ {
+        transitive = false
+    }
+}
+
 // Defining my dependencies. In this case, WPILib (+ friends), and vendor libraries.
 // Also defines JUnit 4.
 dependencies {
     annotationProcessor wpi.java.deps.wpilibAnnotations()
     implementation wpi.java.deps.wpilib()
     implementation wpi.java.vendor.java()
+    customAspectJ wpi.java.vendor.java().findAll { dep -> dep.get().matches(/.*NewCommands.*/) }
 
     roborioDebug wpi.java.deps.wpilibJniDebug(wpi.platforms.roborio)
     roborioDebug wpi.java.vendor.jniDebug(wpi.platforms.roborio)
@@ -128,6 +135,7 @@ dependencies {
     implementation 'org.aspectj:aspectjrt:1.9.22'
 
     implementation project(':SeriouslyCommonLib')
+    customAspectJ project(':SeriouslyCommonLib')
     implementation group: 'org.json', name:'json', version: '20220924'
 
     implementation 'org.apache.logging.log4j:log4j-api:2.19.0'
@@ -147,12 +155,13 @@ dependencies {
 }
 
 compileJava.ajc.options.compilerArgs += "-showWeaveInfo"
+compileJava.ajc.options.inpath.from(configurations.customAspectJ)
 
 wpi.sim.addGui().defaultEnabled = true
 wpi.sim.addDriverstation()
 
 jar {
-    from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
+    from { configurations.runtimeClasspath.findAll({ p -> !p.name.matches(/.*NewCommands.*/) && !p.name.matches(/.*SeriouslyCommonLib.*/) }).collect { it.isDirectory() ? it : zipTree(it) } }
     manifest edu.wpi.first.gradlerio.GradleRIOPlugin.javaManifest(ROBOT_MAIN_CLASS)
     duplicatesStrategy = DuplicatesStrategy.INCLUDE
 }

--- a/src/main/java/competition/aspects/CommandTracer.java
+++ b/src/main/java/competition/aspects/CommandTracer.java
@@ -2,6 +2,7 @@ package competition.aspects;
 
 import edu.wpi.first.wpilibj.Preferences;
 import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj2.command.Command;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
@@ -52,14 +53,14 @@ public class CommandTracer {
         }
     }
 
-    @Before("execution(* edu.wpi.first.wpilibj2.command.Command.initialize(..))" +
-            "|| execution(* edu.wpi.first.wpilibj2.command.Command.execute(..))" +
-            "|| execution(* edu.wpi.first.wpilibj2.command.Command.end(..))")
+    @Before("execution(* edu.wpi.first.wpilibj2.command.Command+.initialize(..))" +
+            "|| execution(* edu.wpi.first.wpilibj2.command.Command+.execute(..))" +
+            "|| execution(* edu.wpi.first.wpilibj2.command.Command+.end(..))")
     public void logCommand(JoinPoint joinPoint) {
         var enableTracing = Preferences.getBoolean(PREFERENCES_KEY, false);
         if (openedFile && enableTracing) {
             try {
-                writer.write(String.format("%f: -> %s\n", Timer.getTimestamp(), joinPoint.toShortString()));
+                writer.write(String.format("%f: -> %s %s\n", Timer.getTimestamp(), ((Command)joinPoint.getThis()).getName(), joinPoint.toShortString()));
             } catch (IOException ignored) {}
         }
     }


### PR DESCRIPTION
# Why are we doing this?

Asana task URL:

# Whats changing?

# Questions/notes for reviewers

# How this was tested
- [ ] tested on robot
- [x] tested in simulator
- [ ] unit tests added

## Video/screenshots (from simulator or live robot)

Sample cycle log:
13.469439: execution(Robot.loopFunc())
13.469439: -> SwerveDriveWithJoysticksCommand execution(SwerveDriveWithJoysticksCommand.execute())
13.469439: -> SwerveDriveMaintainerCommand execution(BaseMaintainerCommand.execute())
13.469439: -> SwerveSteeringMaintainerCommand execution(BaseMaintainerCommand.execute())
13.469439: -> SwerveDriveMaintainerCommand execution(BaseMaintainerCommand.execute())
13.469439: -> SwerveSteeringMaintainerCommand execution(BaseMaintainerCommand.execute())
13.469439: -> SwerveDriveMaintainerCommand execution(BaseMaintainerCommand.execute())
13.469439: -> SwerveSteeringMaintainerCommand execution(BaseMaintainerCommand.execute())
13.469439: -> SwerveDriveMaintainerCommand execution(BaseMaintainerCommand.execute())
13.469439: -> SwerveSteeringMaintainerCommand execution(BaseMaintainerCommand.execute())
13.469439: -> AlgaeCollectionStopCommand execution(Command.execute())
13.469439: -> ElevatorMaintainerCommand execution(BaseMaintainerCommand.execute())
13.469439: -> CoralArmMaintainerCommand execution(BaseMaintainerCommand.execute())
13.469439: -> AlgaeArmMaintainerCommand execution(BaseMaintainerCommand.execute())
13.469439: -> ClimbWithJoySticksCommand execution(ClimbWithJoySticksCommand.execute())

-----

PR feedback legend

 
| Symbol | Meaning                  |
|--------|--------------------------|
| :star: :star: :star:     | must be addressed                 |
| :star: :star:     | should be addressed        |
| :star:     | something to consider, a good idea                  |
