### PR TITLE
Log subsystem times using Advantage Kit

### DIFF
--- a/src/main/java/competition/aspects/SubsystemTracer.java
+++ b/src/main/java/competition/aspects/SubsystemTracer.java
@@ -1,0 +1,76 @@
+package competition.aspects;
+
+import edu.wpi.first.wpilibj.Preferences;
+import edu.wpi.first.wpilibj.RobotController;
+import edu.wpi.first.wpilibj.Timer;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.After;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.littletonrobotics.junction.Logger;
+import xbot.common.command.BaseSubsystem;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@Aspect
+public class SubsystemTracer {
+
+    public Map<BaseSubsystem, Long> refreshDataFrameTimes = new HashMap<>();
+    public Map<BaseSubsystem, Long> periodicTimes = new HashMap<>();
+
+    @Before("execution(* edu.wpi.first.wpilibj.IterativeRobotBase.loopFunc(..))")
+    public void clearMeasurements(JoinPoint joinPoint) {
+        refreshDataFrameTimes.clear();
+        periodicTimes.clear();
+    }
+
+    @After("execution(* edu.wpi.first.wpilibj.IterativeRobotBase.loopFunc(..))")
+    public void reportMeasurements(JoinPoint joinPoint) {
+        // both should be the same length
+        if (refreshDataFrameTimes.isEmpty()) {
+            return;
+        }
+
+        Logger.recordOutput("Performance/Subsystems/Total/refreshDataFrame",
+                refreshDataFrameTimes.values().stream().reduce(0L, Long::sum));
+        Logger.recordOutput("Performance/Subsystems/Total/periodic",
+                periodicTimes.values().stream().reduce(0L, Long::sum));
+        Logger.recordOutput("Performance/Subsystems/Total/total",
+                refreshDataFrameTimes.values().stream().reduce(0L, Long::sum)
+                + periodicTimes.values().stream().reduce(0L, Long::sum));
+    }
+
+    @Around("execution(* xbot.common.command.BaseSubsystem+.refreshDataFrame())")
+    public void measureSubsystemRefreshDataFrame(ProceedingJoinPoint joinPoint) throws Throwable {
+        var startTime = RobotController.getFPGATime();
+        joinPoint.proceed();
+        var endTime = RobotController.getFPGATime();
+
+        var subsystem = (BaseSubsystem)joinPoint.getThis();
+        var time = endTime - startTime;
+        refreshDataFrameTimes.put(subsystem, time);
+
+        Logger.runEveryN(5, () -> Logger.recordOutput("Performance/Subsystems/"
+                + subsystem.getName() + subsystem.hashCode()
+                + "/refreshDataFrame", time));
+    }
+
+    @Around("execution(* xbot.common.command.BaseSubsystem+.periodic())")
+    public void measureSubsystemPeriodic(ProceedingJoinPoint joinPoint) throws Throwable {
+        var startTime = RobotController.getFPGATime();
+        joinPoint.proceed();
+        var endTime = RobotController.getFPGATime();
+
+        var subsystem = (BaseSubsystem)joinPoint.getThis();
+        var time = endTime - startTime;
+        periodicTimes.put(subsystem, time);
+
+        Logger.runEveryN(5, () -> Logger.recordOutput("Performance/Subsystems/"
+                + subsystem.getName() + subsystem.hashCode()
+                + "/periodic", time));
+    }
+}


### PR DESCRIPTION
# Why are we doing this?
We have fishy robot performance issues, so we need more data.

# Whats changing?
Emit telemetry around all subsystem periodic() and refreshDataFrame() calls

# Questions/notes for reviewers

# How this was tested
- [ ] tested on robot
- [x] tested in simulator
- [ ] unit tests added

## Video/screenshots (from simulator or live robot)
![image](https://github.com/user-attachments/assets/60541031-53dc-4020-b33c-77cb3e12a7b6)

-----

PR feedback legend

 
| Symbol | Meaning                  |
|--------|--------------------------|
| :star: :star: :star:     | must be addressed                 |
| :star: :star:     | should be addressed        |
| :star:     | something to consider, a good idea                  |
