### PR TITLE
ElevatorMaintainer: use a different profile for going down vs up

### DIFF
--- a/src/main/java/competition/subsystems/elevator/ElevatorSubsystem.java
+++ b/src/main/java/competition/subsystems/elevator/ElevatorSubsystem.java
@@ -357,9 +357,9 @@ public class ElevatorSubsystem extends BaseSetpointSubsystem<Distance> {
             setTargetValue(getCurrentValue());
         }
 
-        aKitLog.record("ElevatorTrimValue", trimValue.get().in(Inches));
-        aKitLog.record("ElevatorTargetHeight-m", elevatorTargetHeight.in(Inches));
-        aKitLog.record("ElevatorCurrentHeight-m", getCurrentValue().in(Inches));
+        aKitLog.record("ElevatorTrimValue", trimValue.get().in(Meters));
+        aKitLog.record("ElevatorTargetHeight-m", elevatorTargetHeight.in(Meters));
+        aKitLog.record("ElevatorCurrentHeight-m", getCurrentValue().in(Meters));
         aKitLog.record("ElevatorBottomSensor", this.isTouchingBottom());
         aKitLog.record("isElevatorCalibrated", isCalibrated());
         aKitLog.record("isElevatorMaintainerAtGoal", this.isMaintainerAtGoal());

--- a/src/main/java/competition/subsystems/elevator/commands/ElevatorMaintainerCommand.java
+++ b/src/main/java/competition/subsystems/elevator/commands/ElevatorMaintainerCommand.java
@@ -39,6 +39,7 @@ public class ElevatorMaintainerCommand extends BaseMaintainerCommand<Distance> {
     final TrapezoidProfileManager.Factory trapezoidProfileManagerFactory;
     TrapezoidProfileManager upProfileManager;
     TrapezoidProfileManager downProfileManager;
+    boolean goingUp = true;
 
     final ElectricalContract contract;
 
@@ -121,6 +122,15 @@ public class ElevatorMaintainerCommand extends BaseMaintainerCommand<Distance> {
         aKitLog.record("PM-CurrentVelocity", elevator.getCurrentVelocity().in(MetersPerSecond));
         aKitLog.setLogLevel(AKitLogger.LogLevel.INFO);
 
+        // only switch profiles when we're making a big change in direction so it doesn't
+        // thrash around the goal
+        var minTargetDifference = Inches.of(12);
+        if(elevator.getTargetValue().in(Meters) <= currentValue.minus(minTargetDifference).in(Meters)) {
+            goingUp = false;
+        } else if(elevator.getTargetValue().in(Meters) >= currentValue.plus(minTargetDifference).in(Meters)) {
+            goingUp = true;
+        }
+
         upProfileManager.setTargetPosition(
             elevator.getTargetValue().in(Meters),
             currentValue.in(Meters),
@@ -132,14 +142,15 @@ public class ElevatorMaintainerCommand extends BaseMaintainerCommand<Distance> {
             elevator.getCurrentVelocity().in(MetersPerSecond)
         );
 
-        var currentProfileManager = upProfileManager;
-        if(elevator.getTargetValue().in(Meters) < currentValue.in(Meters)){
-            currentProfileManager = downProfileManager;
+        var setpoint = upProfileManager.getRecommendedPositionForTime();
+        var downSetpoint = downProfileManager.getRecommendedPositionForTime();
+        
+        if(!goingUp){
+            setpoint = downSetpoint;
         }
 
-        var setpoint = currentProfileManager.getRecommendedPositionForTime();
         aKitLog.record("elevatorProfileTarget", setpoint);
-
+        aKitLog.record("goingUp", goingUp);
         elevator.setElevatorHeightGoalOnMotor(setpoint);
     }
 

--- a/src/main/java/competition/subsystems/elevator/commands/ElevatorMaintainerCommand.java
+++ b/src/main/java/competition/subsystems/elevator/commands/ElevatorMaintainerCommand.java
@@ -125,10 +125,17 @@ public class ElevatorMaintainerCommand extends BaseMaintainerCommand<Distance> {
         // only switch profiles when we're making a big change in direction so it doesn't
         // thrash around the goal
         var minTargetDifference = Inches.of(12);
-        if(elevator.getTargetValue().in(Meters) <= currentValue.minus(minTargetDifference).in(Meters)) {
+        if(goingUp && elevator.getTargetValue().in(Meters) <= currentValue.minus(minTargetDifference).in(Meters)) {
             goingUp = false;
-        } else if(elevator.getTargetValue().in(Meters) >= currentValue.plus(minTargetDifference).in(Meters)) {
+            downProfileManager.resetState(
+                elevator.getCurrentValue().in(Meters),
+                elevator.getCurrentVelocity().in(MetersPerSecond));
+
+        } else if(!goingUp && elevator.getTargetValue().in(Meters) >= currentValue.plus(minTargetDifference).in(Meters)) {
             goingUp = true;
+            upProfileManager.resetState(
+                elevator.getCurrentValue().in(Meters),
+                elevator.getCurrentVelocity().in(MetersPerSecond));
         }
 
         upProfileManager.setTargetPosition(
@@ -151,6 +158,7 @@ public class ElevatorMaintainerCommand extends BaseMaintainerCommand<Distance> {
 
         aKitLog.record("elevatorProfileTarget", setpoint);
         aKitLog.record("goingUp", goingUp);
+
         elevator.setElevatorHeightGoalOnMotor(setpoint);
     }
 

--- a/src/main/java/competition/subsystems/elevator/commands/ElevatorMaintainerCommand.java
+++ b/src/main/java/competition/subsystems/elevator/commands/ElevatorMaintainerCommand.java
@@ -37,7 +37,8 @@ public class ElevatorMaintainerCommand extends BaseMaintainerCommand<Distance> {
     final DoubleProperty gravityPIDConstantPower;
 
     final TrapezoidProfileManager.Factory trapezoidProfileManagerFactory;
-    TrapezoidProfileManager profileManager;
+    TrapezoidProfileManager upProfileManager;
+    TrapezoidProfileManager downProfileManager;
 
     final ElectricalContract contract;
 
@@ -70,12 +71,19 @@ public class ElevatorMaintainerCommand extends BaseMaintainerCommand<Distance> {
     }
 
     private void createNewProfileManager(){
-        profileManager = trapezoidProfileManagerFactory.create(
-                getPrefix() + "trapezoidMotion",
+        upProfileManager = trapezoidProfileManagerFactory.create(
+                getPrefix() + "trapezoidMotionUp",
                 5, // 5 for competition
                 3.5, // 3.5 for competition
                 0.16, //tune for real robot
                 elevator.getCurrentValue().in(Meters));
+        downProfileManager = trapezoidProfileManagerFactory.create(
+                getPrefix() + "trapezoidMotionDown",
+                2, // 5 for competition
+                1.5, // 3.5 for competition
+                0.16, //tune for real robot
+                elevator.getCurrentValue().in(Meters));
+            
     }
 
     @Override
@@ -113,12 +121,23 @@ public class ElevatorMaintainerCommand extends BaseMaintainerCommand<Distance> {
         aKitLog.record("PM-CurrentVelocity", elevator.getCurrentVelocity().in(MetersPerSecond));
         aKitLog.setLogLevel(AKitLogger.LogLevel.INFO);
 
-        profileManager.setTargetPosition(
+        upProfileManager.setTargetPosition(
             elevator.getTargetValue().in(Meters),
             currentValue.in(Meters),
             elevator.getCurrentVelocity().in(MetersPerSecond)
         );
-        var setpoint = profileManager.getRecommendedPositionForTime();
+        downProfileManager.setTargetPosition(
+            elevator.getTargetValue().in(Meters),
+            currentValue.in(Meters),
+            elevator.getCurrentVelocity().in(MetersPerSecond)
+        );
+
+        var currentProfileManager = upProfileManager;
+        if(elevator.getTargetValue().in(Meters) < currentValue.in(Meters)){
+            currentProfileManager = downProfileManager;
+        }
+
+        var setpoint = currentProfileManager.getRecommendedPositionForTime();
         aKitLog.record("elevatorProfileTarget", setpoint);
 
         elevator.setElevatorHeightGoalOnMotor(setpoint);


### PR DESCRIPTION
# Why are we doing this?

When we're lowering the elevator, we constantly slam it into the bottom. This is partly because we've primarily tuned the profile for going up quickly to score. But coming down with gravity assist the deceleration is not slow enough.

This PR adds a second profile that can be tuned to be more gentle for the way down.

Asana task URL:

# Whats changing?

# Questions/notes for reviewers

Even better would be just changing profile for the deceleration part of going down but that'll be more complicated to notice and swap I think?

# How this was tested
- [ ] tested on robot
- [ ] tested in simulator
- [ ] unit tests added

Going up took 1.2s, coming down 1.6.

![image](https://github.com/user-attachments/assets/0cf14966-2643-45f8-ac42-2d9f35421a20)


## Video/screenshots (from simulator or live robot)

-----

PR feedback legend

 
| Symbol | Meaning                  |
|--------|--------------------------|
| :star: :star: :star:     | must be addressed                 |
| :star: :star:     | should be addressed        |
| :star:     | something to consider, a good idea                  |
