### PR TITLE
Only consume the freshest LaserCAN updates

### DIFF
--- a/src/main/java/competition/simulation/elevator/ElevatorSimulator.java
+++ b/src/main/java/competition/simulation/elevator/ElevatorSimulator.java
@@ -19,6 +19,7 @@ import edu.wpi.first.units.Units;
 import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.wpilibj.RobotController;
 import edu.wpi.first.wpilibj.simulation.ElevatorSim;
+import org.littletonrobotics.junction.Logger;
 import xbot.common.advantage.AKitLogger;
 import xbot.common.controls.actuators.mock_adapters.MockCANMotorController;
 import xbot.common.controls.sensors.mock_adapters.MockLaserCAN;
@@ -38,6 +39,7 @@ public class ElevatorSimulator {
     final ElectricalContract electricalContract;
     final double gravityFeedForward = 0.02;
     final double laserNoiseInMeters = 0.01;
+    final int laserUpdateCycleCount = 3;
 
     final ElevatorSubsystem elevatorSubsystem;
     final MockCANMotorController motor;
@@ -93,7 +95,8 @@ public class ElevatorSimulator {
         var elevatorCurrentHeight = getCurrentHeight();
 
         // We'll set our laserSensor distance to our elevator height with some noise (to *mimic reality*)
-        laserSensor.setDistance(elevatorCurrentHeight.in(Meters) + ((Math.random() - 0.5) * laserNoiseInMeters * 2));
+        // We'll only update the laser sensor every 3 cycles to mimic the real sensor's update rate
+        Logger.runEveryN(3, () -> laserSensor.setDistance(elevatorCurrentHeight.in(Meters) + ((Math.random() - 0.5) * laserNoiseInMeters * 2)));
 
         // update the motor encoder position based on the elevator height, add in the
         // random from zero offset

--- a/src/main/java/competition/subsystems/elevator/ElevatorSubsystem.java
+++ b/src/main/java/competition/subsystems/elevator/ElevatorSubsystem.java
@@ -26,10 +26,11 @@ import xbot.common.properties.Property.PropertyLevel;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import java.util.Optional;
+
 import static edu.wpi.first.units.Units.Degrees;
 import static edu.wpi.first.units.Units.Hertz;
 import static edu.wpi.first.units.Units.Inches;
-import static edu.wpi.first.units.Units.Meter;
 import static edu.wpi.first.units.Units.Meters;
 import static edu.wpi.first.units.Units.MetersPerSecond;
 import static edu.wpi.first.units.Units.Rotations;
@@ -76,6 +77,8 @@ public class ElevatorSubsystem extends BaseSetpointSubsystem<Distance> {
     public final DistanceProperty trimValue;
     public final DistanceProperty trimChangeAmount;
 
+    public final DoubleProperty laserCanMaxMeasurementLatency;
+
     public final XDigitalInput bottomSensor;
     public final XLaserCAN distanceSensor;
 
@@ -102,7 +105,7 @@ public class ElevatorSubsystem extends BaseSetpointSubsystem<Distance> {
         baseHeight = pf.createPersistentProperty("baseHeight", Inches.of(0));
         trimValue = pf.createPersistentProperty("trimValue",Inches.of(0));
         trimChangeAmount = pf.createPersistentProperty("TrimUpAmount", Inches.of(1));
-
+        laserCanMaxMeasurementLatency = pf.createPersistentProperty("laserCanMaxMeasurementLatency-S", 0.04);
 
 
         //to be tuned
@@ -192,28 +195,46 @@ public class ElevatorSubsystem extends BaseSetpointSubsystem<Distance> {
         }
     }
 
-    public void markElevatorAsCalibratedAgainstLowerLimit() {
-        isCalibrated = true;
-        if (this.masterMotor != null) {
-            laserCANPositionOffset.mut_replace(getRawLaserDistance());
-            elevatorMotorPositionOffset.mut_replace(getRawMotorAngle().copy());
-        } else {
-            laserCANPositionOffset.mut_replace(Meters.zero());
-            elevatorMotorPositionOffset.mut_replace(Rotations.zero());
-        }
+    private boolean trySetLaserCANOffset() {
+        var distance = getRawLaserDistance();
+        distance.ifPresent(laserCANPositionOffset::mut_replace);
+        return distance.isPresent();
     }
 
-    private void calibrateElevatorMotorOffsetViaLaserCAN() {
-        var laserDistance = getCalibratedLaserDistance();
+    private boolean trySetMotorOffset() {
         var motorRotations = getRawMotorAngle();
-        var motorRotationsToZero = Rotations.of(laserDistance.in(Meters) / getMetersPerRotation().in(Meters));
-        elevatorMotorPositionOffset.mut_replace(motorRotations.minus(motorRotationsToZero));
+        if (motorRotations != null) {
+            elevatorMotorPositionOffset.mut_replace(motorRotations);
+            return true;
+        }
+        return false;
+    }
+
+    public boolean tryMarkElevatorCalibratedAgainstLowerLimit() {
+        var success = trySetLaserCANOffset() && trySetMotorOffset();
+        if (success) {
+            isCalibrated = true;
+        }
+        return success;
+    }
+
+    private boolean tryCalibrateMotorOffsetViaLaserCAN() {
+        if (!isCalibrated) {
+            return false;
+        }
+        var laserDistance = getCalibratedLaserDistance();
+        laserDistance.ifPresent(d -> {
+            var motorRotations = getRawMotorAngle();
+            var motorRotationsToZero = Rotations.of(d.in(Meters) / getMetersPerRotation().in(Meters));
+            elevatorMotorPositionOffset.mut_replace(motorRotations.minus(motorRotationsToZero));
+        });
+        return laserDistance.isPresent();
     }
 
     @Override
     public Distance getCurrentValue() {
         return Meters.of(sensorFusionFilter.calculateFilteredValue(
-                getCalibratedLaserDistance().in(Meters),
+                getCalibratedLaserDistance().map(d -> d.in(Meters)).orElse(Double.MAX_VALUE),
                 getCalibratedMotorDistance().in(Meters)));
     }
 
@@ -265,18 +286,19 @@ public class ElevatorSubsystem extends BaseSetpointSubsystem<Distance> {
         return isCalibrated;
     }
 
-    private Distance getCalibratedLaserDistance() {
-        return getRawLaserDistance().minus(laserCANPositionOffset);
+    private Optional<Distance> getCalibratedLaserDistance() {
+        return getRawLaserDistance().map(d -> d.minus(laserCANPositionOffset));
     }
 
-    private Distance getRawLaserDistance() {
+    private Optional<Distance> getRawLaserDistance() {
         if (contract.isElevatorDistanceSensorReady()) {
             var distance = distanceSensor.getDistance();
-            if (distance != null) {
-                return distance;
+            var latency = distanceSensor.getMeasurementLatency();
+            if (distance != null && latency != null && latency.lt(Seconds.of(laserCanMaxMeasurementLatency.get()))) {
+                return Optional.of(distance);
             }
         }
-        return Meter.of(0);
+        return Optional.empty();
     }
 
     private Angle getRawMotorAngle() {
@@ -353,8 +375,9 @@ public class ElevatorSubsystem extends BaseSetpointSubsystem<Distance> {
         }
         //bandage case: isTouchingBottom flashes true for one tick on startup, investigate later?
         if (this.isTouchingBottom() && periodicTickCounter >= 3 && !isCalibrated()) {
-            markElevatorAsCalibratedAgainstLowerLimit();
-            setTargetValue(getCurrentValue());
+            if (tryMarkElevatorCalibratedAgainstLowerLimit()) {
+                setTargetValue(getCurrentValue());
+            }
         }
 
         aKitLog.record("ElevatorTrimValue", trimValue.get().in(Inches));
@@ -364,13 +387,11 @@ public class ElevatorSubsystem extends BaseSetpointSubsystem<Distance> {
         aKitLog.record("isElevatorCalibrated", isCalibrated());
         aKitLog.record("isElevatorMaintainerAtGoal", this.isMaintainerAtGoal());
         isNotCalibratedAlert.set(!isCalibrated());
-        aKitLog.record("ElevatorDistanceSensor-m", getRawLaserDistance().in(Meters));
-        aKitLog.record("CalibratedElevatorDistanceSensor-m", getCalibratedLaserDistance().in(Meters));
+        getRawLaserDistance().ifPresent(d -> aKitLog.record("ElevatorDistanceSensor-m", d.in(Meters)));
+        getCalibratedLaserDistance().ifPresent(d -> aKitLog.record("CalibratedElevatorDistanceSensor-m", d.in(Meters)));
         aKitLog.record("CalibratedElevatorMotorSensor-m", getCalibratedMotorDistance().in(Meters));
         aKitLog.record("MotorOffset-rotations", elevatorMotorPositionOffset.in(Rotations));
 
         periodicTickCounter++;
     }
-
-
 }

--- a/src/main/java/competition/subsystems/elevator/commands/ElevatorMaintainerCommand.java
+++ b/src/main/java/competition/subsystems/elevator/commands/ElevatorMaintainerCommand.java
@@ -7,7 +7,6 @@ import competition.subsystems.elevator.ElevatorSubsystem;
 import edu.wpi.first.units.measure.Distance;
 import xbot.common.advantage.AKitLogger;
 import xbot.common.command.BaseMaintainerCommand;
-import xbot.common.controls.actuators.XCANMotorController;
 import xbot.common.logic.CalibrationDecider;
 import xbot.common.logic.HumanVsMachineDecider;
 import xbot.common.math.MathUtils;
@@ -18,7 +17,6 @@ import xbot.common.properties.PropertyFactory;
 import static edu.wpi.first.units.Units.Inches;
 import static edu.wpi.first.units.Units.Meters;
 import static edu.wpi.first.units.Units.MetersPerSecond;
-import static edu.wpi.first.units.Units.Rotations;
 import static xbot.common.logic.CalibrationDecider.CalibrationMode.GaveUp;
 
 import javax.inject.Inject;
@@ -140,7 +138,7 @@ public class ElevatorMaintainerCommand extends BaseMaintainerCommand<Distance> {
         elevator.setPower(elevator.calibrationNegativePower.get());
 
         if (elevator.isTouchingBottom()) {
-            elevator.markElevatorAsCalibratedAgainstLowerLimit();
+            elevator.tryMarkElevatorCalibratedAgainstLowerLimit();
             elevator.setTargetValue(elevator.getCurrentValue());
         }
     }

--- a/src/main/java/competition/subsystems/elevator/commands/ForceElevatorCalibratedCommand.java
+++ b/src/main/java/competition/subsystems/elevator/commands/ForceElevatorCalibratedCommand.java
@@ -18,7 +18,7 @@ public class ForceElevatorCalibratedCommand extends BaseCommand {
     @Override
     public void initialize() {
         log.info("Initializing..");
-        elevator.markElevatorAsCalibratedAgainstLowerLimit();
+        elevator.tryMarkElevatorCalibratedAgainstLowerLimit();
         elevator.setTargetValue(elevator.getCurrentValue());
         this.setRunsWhenDisabled(true);
     }

--- a/src/test/java/competition/subsystems/elevator/ElevatorSubsystemDisabledTest.java
+++ b/src/test/java/competition/subsystems/elevator/ElevatorSubsystemDisabledTest.java
@@ -52,6 +52,6 @@ public class ElevatorSubsystemDisabledTest extends BaseCompetitionTest {
 
         assertFalse(subsystem.isTouchingBottom());
 
-        subsystem.markElevatorAsCalibratedAgainstLowerLimit();
+        subsystem.tryMarkElevatorCalibratedAgainstLowerLimit();
     }
 }


### PR DESCRIPTION
# Why are we doing this?
LaserCAN updates happen less frequently than the robot code loop. We don't want to calibrate positions off of stale data, so make sure that we only report LaserCAN measurements while they're reasonably fresh.

# Whats changing?

# Questions/notes for reviewers

# How this was tested
- [x] tested on robot
- [x] tested in simulator
- [ ] unit tests added

## Video/screenshots (from simulator or live robot)
![image](https://github.com/user-attachments/assets/be282a0a-c8ef-4b23-b1a9-434f67a07776)

-----

PR feedback legend

 
| Symbol | Meaning                  |
|--------|--------------------------|
| :star: :star: :star:     | must be addressed                 |
| :star: :star:     | should be addressed        |
| :star:     | something to consider, a good idea                  |
