### PR TITLE
bail on align to reef if the camera isn't connected

### DIFF
--- a/src/main/java/competition/subsystems/drive/commands/AlignToReefWithAprilTagCommand.java
+++ b/src/main/java/competition/subsystems/drive/commands/AlignToReefWithAprilTagCommand.java
@@ -69,19 +69,21 @@ public class AlignToReefWithAprilTagCommand extends AlignToTagGlobalMovementWith
         }
 
         if (!aprilTagVisionSubsystem.isCameraConnected(cameraToUse)) {
+            // if the camera isn't connected, we can't really do this
+            // rumble to notify driver
             oi.driverGamepad.getRumbleManager().rumbleGamepad(1, 1);
+        } else {
+            super.setConfigurations(
+                    cameraToUse,
+                    aprilTagVisionSubsystem.getTargetAprilTagID(pose.getClosestReefFacePose()),
+                    isCameraBackwards,
+                    offsetInInches,
+                    startingActivity,
+                    enableRetries
+            );
+    
+            super.initialize();
         }
-
-        super.setConfigurations(
-                cameraToUse,
-                aprilTagVisionSubsystem.getTargetAprilTagID(pose.getClosestReefFacePose()),
-                isCameraBackwards,
-                offsetInInches,
-                startingActivity,
-                enableRetries
-        );
-
-        super.initialize();
     }
 
     private void setDriverRelativeCameraToUse() {

--- a/src/main/java/competition/subsystems/drive/commands/AlignToTagGlobalMovementWithCalculator.java
+++ b/src/main/java/competition/subsystems/drive/commands/AlignToTagGlobalMovementWithCalculator.java
@@ -83,6 +83,9 @@ public class AlignToTagGlobalMovementWithCalculator extends BaseCommand {
 
     @Override
     public void execute() {
+        if(!hasSetConfiguration) {
+            return;
+        }
         var advice = calculator.getXYPowersAlignToAprilTag(pose.getCurrentPose2d());
         aKitLog.record("driveValues", advice.driveIntent());
         drive.fieldOrientedDrive(
@@ -94,7 +97,7 @@ public class AlignToTagGlobalMovementWithCalculator extends BaseCommand {
 
     @Override
     public boolean isFinished() {
-        return calculator.recommendIsFinished();
+        return hasSetConfiguration && calculator.recommendIsFinished();
     }
 
     @Override


### PR DESCRIPTION
# Why are we doing this?

When the cameras were off, auto went bananas and just drove forward as fast as it could. It's safer if this just sits there and doesn't move. I opted for it to not end so that it doesn't continue auto (by scoring a coral into mid air)

Asana task URL:

# Whats changing?

# Questions/notes for reviewers

# How this was tested
- [ ] tested on robot
- [ ] tested in simulator
- [ ] unit tests added

## Video/screenshots (from simulator or live robot)

-----

PR feedback legend

 
| Symbol | Meaning                  |
|--------|--------------------------|
| :star: :star: :star:     | must be addressed                 |
| :star: :star:     | should be addressed        |
| :star:     | something to consider, a good idea                  |
