### PR TITLE
Update coral arm in sim and superstructure vis

### DIFF
--- a/src/main/java/competition/electrical_contract/UnitTestContract2025.java
+++ b/src/main/java/competition/electrical_contract/UnitTestContract2025.java
@@ -17,7 +17,8 @@ public class UnitTestContract2025 extends Contract2025 {
 
     public boolean isCoralArmMotorReady() { return true; }
 
-    public boolean isCoralArmPivotAbsoluteEncoderReady() { return true; }
+    // we don't have plans to have this sensor on the robot
+    public boolean isCoralArmPivotAbsoluteEncoderReady() { return false; }
 
     public boolean isCoralArmLowSensorReady() { return true; }
 

--- a/src/main/java/competition/simulation/coral_arm/CoralArmSimConstants.java
+++ b/src/main/java/competition/simulation/coral_arm/CoralArmSimConstants.java
@@ -10,14 +10,16 @@ import edu.wpi.first.units.measure.Mass;
 
 public class CoralArmSimConstants {
     // TODO: this is all from the wpilib example but doesn't reflect our real math
-    public static final double armReduction = 200;
+    public static final double armReduction = 50;
     public static final Mass armMass = Kilogram.of(8.0); // Kilograms
     public static final Distance armLength = Meters.of(0.5);
+
     // the frame of reference for these angles is 0' right, 90' up, 180' left, 270' down
     // so we have 225 as the starting angle which is 0' in arm relative terms
-    public static final Angle minAngleRads = Degrees.of(225 - 180);
-    public static final Angle armEncoderAnglePerRotation = Degrees.of(6.94444);
-    public static final Angle angleAtRobotZero = Degrees.of(225);
-    public static final Angle maxAngleRads = Degrees.of(225);
+    public static final Angle armEncoderAnglePerRotation = Degrees.of(5.790);
+    public static final Angle maxAngleRads = Degrees.of(245);
+    public static final Angle angleAtRobotZero = maxAngleRads;
     public static final Angle startingAngle = maxAngleRads;
+    // subtrack the range of motion from the starting angle to get the min angle
+    public static final Angle minAngleRads = startingAngle.minus(Degrees.of(230));
 }

--- a/src/main/java/competition/simulation/coral_arm/CoralArmSimulator.java
+++ b/src/main/java/competition/simulation/coral_arm/CoralArmSimulator.java
@@ -38,7 +38,8 @@ public class CoralArmSimulator {
     final ElectricalContract contract;
 
     @Inject
-    public CoralArmSimulator(CoralArmSubsystem armPivotSubsystem, PIDManager.PIDManagerFactory pidManagerFactory, PropertyFactory pf, ElectricalContract contract) {
+    public CoralArmSimulator(CoralArmSubsystem armPivotSubsystem, PIDManager.PIDManagerFactory pidManagerFactory,
+            PropertyFactory pf, ElectricalContract contract) {
         pf.setPrefix("CoralArmSimulator");
         this.aKitLog = new AKitLogger("FieldSimulation/CoralArm");
         this.contract = contract;

--- a/src/main/java/competition/simulation/coral_arm/CoralArmSimulator.java
+++ b/src/main/java/competition/simulation/coral_arm/CoralArmSimulator.java
@@ -3,6 +3,7 @@ package competition.simulation.coral_arm;
 import javax.inject.Inject;
 
 import competition.Robot;
+import competition.electrical_contract.ElectricalContract;
 import competition.simulation.MotorInternalPIDHelper;
 import competition.subsystems.coral_arm.CoralArmSubsystem;
 
@@ -20,7 +21,6 @@ import edu.wpi.first.wpilibj.RobotController;
 import edu.wpi.first.wpilibj.simulation.SingleJointedArmSim;
 import xbot.common.advantage.AKitLogger;
 import xbot.common.controls.actuators.mock_adapters.MockCANMotorController;
-import xbot.common.controls.sensors.mock_adapters.MockAbsoluteEncoder;
 import xbot.common.controls.sensors.mock_adapters.MockDutyCycleEncoder;
 import xbot.common.math.PIDManager;
 import xbot.common.properties.PropertyFactory;
@@ -35,11 +35,13 @@ public class CoralArmSimulator {
     final MockCANMotorController armMotor;
     final MockDutyCycleEncoder absoluteEncoder;
     final MockDigitalInput lowSensor;
+    final ElectricalContract contract;
 
     @Inject
-    public CoralArmSimulator(CoralArmSubsystem armPivotSubsystem, PIDManager.PIDManagerFactory pidManagerFactory, PropertyFactory pf) {
+    public CoralArmSimulator(CoralArmSubsystem armPivotSubsystem, PIDManager.PIDManagerFactory pidManagerFactory, PropertyFactory pf, ElectricalContract contract) {
         pf.setPrefix("CoralArmSimulator");
         this.aKitLog = new AKitLogger("FieldSimulation/CoralArm");
+        this.contract = contract;
         this.pidManager = pidManagerFactory.create(pf.getPrefix() + "/CANMotorPositionalPID", 0.2, 0.001, 0.0, 0.0, 1.0, -1.0);
         this.armPivotSubsystem = armPivotSubsystem;
         this.armMotor = (MockCANMotorController) armPivotSubsystem.armMotor;
@@ -77,8 +79,10 @@ public class CoralArmSimulator {
         var armMotorRotations = armRelativeAngle.in(Radians) / CoralArmSimConstants.armEncoderAnglePerRotation.in(Radians);
         armMotor.setPosition(Rotations.of(armMotorRotations));
 
-        absoluteEncoder.setRawPosition(getAbsoluteEncoderPosition(getArmAngle(), 0.0,
-                armPivotSubsystem.rangeOfMotionDegrees.get() / 360).in(Rotations) + 0.5);
+        if(contract.isCoralArmPivotAbsoluteEncoderReady()) {
+            absoluteEncoder.setRawPosition(getAbsoluteEncoderPosition(getArmAngle(), 0.0,
+                    armPivotSubsystem.rangeOfMotionDegrees.get() / 360).in(Rotations) + 0.5);
+        }
 
         // if the arm angle is lower than 10.8 degrees it will return true, otherwise return false
         lowSensor.setValue(getArmAngle().in(Degrees) < 10.8);

--- a/src/main/java/competition/subsystems/elevator/SuperstructureMechanism.java
+++ b/src/main/java/competition/subsystems/elevator/SuperstructureMechanism.java
@@ -31,7 +31,7 @@ public class SuperstructureMechanism {
     // these constants define the mechanism geometry rendering at zero height and zero angle
     // all tuned by trial and error
     public final double elevatorLigamentBaseLengthMeters = 0.7;
-    final double coralArmLigamentBaseAngleDegrees = 145;
+    final double coralArmLigamentBaseAngleDegrees = 165;
     final double coralArmLengthMeters = 0.47;
     final double scorerLengthMeters = 0.6;
     final double scorerAngleDegrees = -145;


### PR DESCRIPTION
# Why are we doing this?

Asana task URL:

# Whats changing?

- Disable the arm absolute encoder in unit test contract, we don't have the device and probably never will
- Update the superstructure vis so that 0' arm angle is now the new bottom spot
- Change the params of the coral arm sim to match the new positioning


# Questions/notes for reviewers

# How this was tested
- [ ] tested on robot
- [x] tested in simulator
- [ ] unit tests added

##  Video/screenshots (from simulator or live robot)

https://github.com/user-attachments/assets/b7b78b84-67e6-4b73-9b22-a8e58b69bdc4


-----

PR feedback legend

 
| Symbol | Meaning                  |
|--------|--------------------------|
| :star: :star: :star:     | must be addressed                 |
| :star: :star:     | should be addressed        |
| :star:     | something to consider, a good idea                  |
