### PR TITLE
change default value of EmergencyAutoCommand's drive forward power

### DIFF
--- a/src/main/java/competition/subsystems/drive/commands/EmergencyAutonomousCommand.java
+++ b/src/main/java/competition/subsystems/drive/commands/EmergencyAutonomousCommand.java
@@ -26,8 +26,8 @@ public class EmergencyAutonomousCommand extends BaseCommand {
         pf.setPrefix(this);
         this.drive = drive;
         this.addRequirements(drive);
-        this.moveRobotX = pf.createPersistentProperty("Move robot X", 1);
-        this.timeAmountToMove= pf.createPersistentProperty("Seconds it moves",1);
+        this.moveRobotX = pf.createPersistentProperty("Move robot X", 0.2);
+        this.timeAmountToMove= pf.createPersistentProperty("Seconds it moves", 1);
 
     }
 


### PR DESCRIPTION
# Why are we doing this?

Emergency auto was trying to drive forward at 100% power which is CRAZY fast, it would almost instantly slam into whatever was infront of it before the drivers have a chance to hit the A-Stop button.

This value will need to be updated on the robot as well.

Asana task URL:

# Whats changing?

# Questions/notes for reviewers

# How this was tested
- [ ] tested on robot
- [ ] tested in simulator
- [ ] unit tests added

## Video/screenshots (from simulator or live robot)

-----

PR feedback legend

 
| Symbol | Meaning                  |
|--------|--------------------------|
| :star: :star: :star:     | must be addressed                 |
| :star: :star:     | should be addressed        |
| :star:     | something to consider, a good idea                  |
