### PR TITLE
Update the CommandTracer so that it can capture commands that complet…

### DIFF
--- a/src/main/java/competition/aspects/CommandTracer.java
+++ b/src/main/java/competition/aspects/CommandTracer.java
@@ -10,7 +10,10 @@ import xbot.common.command.BaseMaintainerCommand;
 import xbot.common.controls.sensors.XTimer;
 
 import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 
 // CHECKSTYLE:OFF
 @Aspect
@@ -20,6 +23,14 @@ public class CommandTracer {
 
     private final Map<Command, Double> commandStartTimes = new HashMap<>();
     private final Map<Command, Alert> runningCommandAlerts = new HashMap<>();
+    private final LinkedList<Alert> completedAlertList = new LinkedList<>();
+
+    @Before("execution(* edu.wpi.first.wpilibj.IterativeRobotBase.loopFunc(..))")
+    public void clearAlertsForFinishedCommands(JoinPoint joinPoint) {
+        while (!completedAlertList.isEmpty()) {
+            completedAlertList.poll().close();
+        }
+    }
 
     @Before("execution(* edu.wpi.first.wpilibj2.command.Command+.initialize(..))" +
             "|| execution(* edu.wpi.first.wpilibj2.command.Command+.execute(..))")
@@ -39,7 +50,7 @@ public class CommandTracer {
         if (runningCommandAlerts.containsKey((Command)joinPoint.getThis())) {
             var command = (Command)joinPoint.getThis();
             var wasInterrupted = (Boolean)joinPoint.getArgs()[0];
-            runningCommandAlerts.remove(command).close();
+            completedAlertList.add(runningCommandAlerts.remove(command));
             var startTime = commandStartTimes.remove(command);
             var endTime = XTimer.getFPGATimestamp();
             logger.info("Command {} took {} seconds (interrupted: {})",


### PR DESCRIPTION
…e within a single scheduler cycle.

# Why are we doing this?
Depending on how a command is scheduled, it might finish in the same scheduler cycle that it is started. If this happens, the previous code would not have emitted an alert at all.

# Whats changing?
For all command finished alerts, keep them in a list to be cleared at the start of the next robot periodic cycle.

# Questions/notes for reviewers

# How this was tested
- [ ] tested on robot
- [x] tested in simulator
- [ ] unit tests added

## Video/screenshots (from simulator or live robot)

-----

PR feedback legend

 
| Symbol | Meaning                  |
|--------|--------------------------|
| :star: :star: :star:     | must be addressed                 |
| :star: :star:     | should be addressed        |
| :star:     | something to consider, a good idea                  |
