### PR TITLE
Add algea collection angles and merge with elevator height target setting

### DIFF
--- a/src/main/java/competition/operator_interface/OperatorCommandMap.java
+++ b/src/main/java/competition/operator_interface/OperatorCommandMap.java
@@ -159,14 +159,8 @@ public class OperatorCommandMap {
         oi.operatorGamepad.getifAvailable(XXboxController.XboxButton.LeftTrigger).whileTrue(intakeCoralCommand);
         oi.operatorGamepad.getifAvailable(XXboxController.XboxButton.RightTrigger).whileTrue(scoreCoralCommand);
 
-        var removeHighAlgaeHeight = setElevatorTargetHeightCommandProvider.get();
-        removeHighAlgaeHeight.setHeight(Landmarks.CoralLevel.HIGH_ALGAE);
 
-        var removeLowAlgaeHeight = setElevatorTargetHeightCommandProvider.get();
-        removeLowAlgaeHeight.setHeight(Landmarks.CoralLevel.LOW_ALGAE);
 
-        var scoreAlgaeInNetHeight = setElevatorTargetHeightCommandProvider.get();
-        scoreAlgaeInNetHeight.setHeight(Landmarks.CoralLevel.SCORE_ALGAE_NET);
 
         var calibrateAlgae = Commands.parallel(
                 forceAlgaeArmCalibrated).ignoringDisable(true);
@@ -178,17 +172,13 @@ public class OperatorCommandMap {
         oi.operatorGamepad.getifAvailable(XXboxController.XboxButton.RightStick).onTrue(calibrateAlgae);
         oi.operatorGamepad.getifAvailable(XXboxController.XboxButton.Start).onTrue(calibrateSuperstructure);
         // Algae system buttons
-        var removeLowAlgae = prepAlgaeSystemCommandGroupFactory.create(AlgaeArmSubsystem.AlgaeArmPositions.ReefAlgaeLow);
-        oi.operatorGamepad.getPovIfAvailable(180).onTrue(removeLowAlgaeHeight);
-
-        var removeHighAlgae = prepAlgaeSystemCommandGroupFactory.create(AlgaeArmSubsystem.AlgaeArmPositions.ReefAlgaeHigh);
-        oi.operatorGamepad.getPovIfAvailable(0).onTrue(removeHighAlgaeHeight);
-
-        var collectGroundAlgae = prepAlgaeSystemCommandGroupFactory.create(AlgaeArmSubsystem.AlgaeArmPositions.GroundCollection);
-        oi.operatorGamepad.getPovIfAvailable(90).onTrue(scoreAlgaeInNetHeight);
-
-        var homeAlgaeArm = prepAlgaeSystemCommandGroupFactory.create(AlgaeArmSubsystem.AlgaeArmPositions.FullyRetracted);
-        oi.operatorGamepad.getPovIfAvailable(270).onTrue(homeAlgaeArm);
+        
+        var removeLowAlgae = prepCoralSystemCommandGroupFactory.create(() -> Landmarks.CoralLevel.LOW_ALGAE);
+        
+        oi.operatorGamepad.getPovIfAvailable(180).onTrue(removeLowAlgae);
+        
+        var removeHighAlgae = prepCoralSystemCommandGroupFactory.create(() -> Landmarks.CoralLevel.HIGH_ALGAE);
+        oi.operatorGamepad.getPovIfAvailable(0).onTrue(removeHighAlgae);
 
         oi.operatorGamepad.getifAvailable(XXboxController.XboxButton.LeftBumper).whileTrue(intakeAlgae);
         oi.operatorGamepad.getifAvailable(XXboxController.XboxButton.RightBumper).whileTrue(ejectAlgae);

--- a/src/main/java/competition/operator_interface/OperatorCommandMap.java
+++ b/src/main/java/competition/operator_interface/OperatorCommandMap.java
@@ -180,6 +180,9 @@ public class OperatorCommandMap {
         var removeHighAlgae = prepCoralSystemCommandGroupFactory.create(() -> Landmarks.CoralLevel.HIGH_ALGAE);
         oi.operatorGamepad.getPovIfAvailable(0).onTrue(removeHighAlgae);
 
+        var scoreAlgaeInNetHeight = prepCoralSystemCommandGroupFactory.create(() -> Landmarks.CoralLevel.SCORE_ALGAE_NET);
+        oi.operatorGamepad.getPovIfAvailable(90).onTrue(scoreAlgaeInNetHeight);
+
         oi.operatorGamepad.getifAvailable(XXboxController.XboxButton.LeftBumper).whileTrue(intakeAlgae);
         oi.operatorGamepad.getifAvailable(XXboxController.XboxButton.RightBumper).whileTrue(ejectAlgae);
     }

--- a/src/main/java/competition/subsystems/coral_arm/CoralArmSubsystem.java
+++ b/src/main/java/competition/subsystems/coral_arm/CoralArmSubsystem.java
@@ -48,6 +48,8 @@ public class CoralArmSubsystem extends BaseSetpointSubsystem<Angle> {
     public final DoubleProperty rangeOfMotionDegrees;
     public final DoubleProperty powerWhenNotCalibrated;
     public final DoubleProperty autoCalibrationDegrees;
+    public final DoubleProperty algaeCollectAngleInDegrees;
+    public final DoubleProperty algaeScoreNetAngleInDegrees;
 
     public Landmarks.CoralLevel targetCoralLevel;
 
@@ -97,6 +99,8 @@ public class CoralArmSubsystem extends BaseSetpointSubsystem<Angle> {
         // NOTE: For now, the human loading angle is "vertical" with respect to the ground, which should also match
         // the "AutoCalibrationDegrees" value.
         this.humanLoadAngleDegrees = propertyFactory.createPersistentProperty("Human Loading Angle in Degrees", 13.8);
+        this.algaeCollectAngleInDegrees = propertyFactory.createPersistentProperty("Algae Collect Angle in Degrees", 45);
+        this.algaeScoreNetAngleInDegrees = propertyFactory.createPersistentProperty("Algae Score Net Angle in Degrees", 136);
         propertyFactory.setDefaultLevel(PropertyLevel.Debug);
         this.degreesPerRotations = propertyFactory.createPersistentProperty("Degrees Per Rotations", 5.790);
         this.rangeOfMotionDegrees = propertyFactory.createPersistentProperty("Range of Motion in Degrees", 170);
@@ -176,7 +180,14 @@ public class CoralArmSubsystem extends BaseSetpointSubsystem<Angle> {
             case FOUR:
                 setTargetValue(Degrees.of(level4ScoringAngle.get()));
                 break;
-            case COLLECTING:
+            case LOW_ALGAE:
+            case HIGH_ALGAE:
+                setTargetValue(Degrees.of(algaeCollectAngleInDegrees.get()));
+                break;
+            case SCORE_ALGAE_NET:
+                setTargetValue(Degrees.of(algaeScoreNetAngleInDegrees.get()));
+                break;
+                case COLLECTING:
             default:
                 setTargetValue(Degrees.of(humanLoadAngleDegrees.get()));
                 break;


### PR DESCRIPTION

# Why are we doing this?

Grabs @Glowdisk's work from https://github.com/Team488/TeamXbot2025/pull/323 and merges it in to Junyu's elevator height levels.

Changed commands to be setting both elevator height and coral arm angles.

Asana task URL:

# Whats changing?

# Questions/notes for reviewers

# How this was tested
- [ ] tested on robot
- [x] tested in simulator
- [ ] unit tests added

## Video/screenshots (from simulator or live robot)

-----

PR feedback legend

 
| Symbol | Meaning                  |
|--------|--------------------------|
| :star: :star: :star:     | must be addressed                 |
| :star: :star:     | should be addressed        |
| :star:     | something to consider, a good idea                  |
