### PR TITLE
Minor drive to reef face and align cleanup

### DIFF
--- a/src/main/java/competition/commandgroups/DriveToReefFaceThenAlignCommandGroupFactory.java
+++ b/src/main/java/competition/commandgroups/DriveToReefFaceThenAlignCommandGroupFactory.java
@@ -1,16 +1,14 @@
 package competition.commandgroups;
 
 import competition.subsystems.drive.DriveSubsystem;
-import competition.subsystems.drive.commands.AlignToReefWithAprilTagCommand;
 import competition.subsystems.drive.commands.AlignToTagGlobalMovementWithCalculator;
-import competition.subsystems.drive.commands.DriveToReefFaceUntilDetectionCommand;
 import competition.subsystems.drive.logic.AlignCameraToAprilTagCalculator;
 import competition.subsystems.pose.Cameras;
 import competition.subsystems.pose.Landmarks;
 import competition.subsystems.vision.AprilTagVisionSubsystemExtended;
+import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.DeferredCommand;
-import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
-import xbot.common.controls.sensors.XXboxController;
+import edu.wpi.first.wpilibj2.command.ProxyCommand;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
@@ -44,10 +42,7 @@ public class DriveToReefFaceThenAlignCommandGroupFactory {
         }
     }
 
-    public SequentialCommandGroup create(Landmarks.ReefFace targetReefFace, Landmarks.Branch targetBranch) {
-        var group = new SequentialCommandGroup();
-        group.setName("DriveToReefFaceThenAlignCommandGroup");
-
+    public Command create(Landmarks.ReefFace targetReefFace, Landmarks.Branch targetBranch) {
         var alignToReefCommand = new DeferredCommand(
                 () -> {
                     var alignToReefWithAprilTagCommand = alignToReefWithAprilTagCommandProvider.get();
@@ -55,9 +50,8 @@ public class DriveToReefFaceThenAlignCommandGroupFactory {
                     return alignToReefWithAprilTagCommand;
                 }, Set.of(drive)
         );
-        group.addCommands(
-                alignToReefCommand);
+        alignToReefCommand.setName("DriveToReefFaceThenAlignCommandGroup");
 
-        return group;
+        return alignToReefCommand;
     }
 }

--- a/src/main/java/competition/subsystems/pose/PoseSubsystem.java
+++ b/src/main/java/competition/subsystems/pose/PoseSubsystem.java
@@ -484,7 +484,7 @@ public class PoseSubsystem extends BasePoseSubsystem {
             // This is because we will be using the odometry estimate while vision is being
             // supresse, and we need
             // to avoid any callers of the PoseSubsystem experiencing discontinuities.
-            resetPoseEstimator(fullSwerveOdometry.getEstimatedPosition());
+            resetPoseEstimator(getPrimaryPoseEstimator().getEstimatedPosition());
         }
     }
 


### PR DESCRIPTION
# Why are we doing this?
I want to clean up the Deferred command, but want to check in this unrelated cleanup separately.

# Whats changing?
Remove unnecessary command group layer.
Use deadwheel pose estimator for snapping vision pose

# Questions/notes for reviewers

# How this was tested
- [ ] tested on robot
- [x] tested in simulator
- [ ] unit tests added

## Video/screenshots (from simulator or live robot)

-----

PR feedback legend

 
| Symbol | Meaning                  |
|--------|--------------------------|
| :star: :star: :star:     | must be addressed                 |
| :star: :star:     | should be addressed        |
| :star:     | something to consider, a good idea                  |
