### PR TITLE
add 1s delay to start of key autos

### DIFF
--- a/src/main/java/competition/auto_programs/FromCageScoreOneCoralAutoFactory.java
+++ b/src/main/java/competition/auto_programs/FromCageScoreOneCoralAutoFactory.java
@@ -7,7 +7,10 @@ import competition.subsystems.pose.Landmarks;
 import competition.subsystems.pose.PoseSubsystem;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
+import edu.wpi.first.wpilibj2.command.WaitCommand;
 import xbot.common.subsystems.autonomous.AutonomousCommandSelector;
+
+import static edu.wpi.first.units.Units.Seconds;
 
 import javax.inject.Inject;
 
@@ -37,6 +40,8 @@ public class FromCageScoreOneCoralAutoFactory {
                                                        Landmarks.CoralLevel targetLevel) {
         var auto = new BaseAutonomousSequentialCommandGroup(autoSelector);
         auto.setName("FromCageScoreOneCoralAuto");
+
+        auto.addCommands(new WaitCommand(Seconds.of(1)));
 
         var initializeStateCommand = pose.createSetPositionCommand(
                         () -> PoseSubsystem.convertBlueToRedIfNeeded(startingLocation)

--- a/src/main/java/competition/auto_programs/vision/LeftFourCoralAuto.java
+++ b/src/main/java/competition/auto_programs/vision/LeftFourCoralAuto.java
@@ -14,6 +14,8 @@ import competition.subsystems.pose.vision.Paths;
 import javax.inject.Inject;
 import javax.inject.Provider;
 
+import static edu.wpi.first.units.Units.Seconds;
+
 import edu.wpi.first.wpilibj2.command.WaitCommand;
 import xbot.common.subsystems.autonomous.AutonomousCommandSelector;
 
@@ -26,6 +28,7 @@ public class LeftFourCoralAuto extends BaseAutonomousSequentialCommandGroup {
             Provider<PathDriveToLocationForCoralStationFactory> pathDriveToLocationAndIntakeUntilCollectedProvider) {
         super(autoSelector);
 
+        this.addCommands(new WaitCommand(Seconds.of(1)));
 
         // Score 1
         getDriveAndScoreStatusMessageCommand(Landmarks.ReefFace.FAR_LEFT,

--- a/src/main/java/competition/auto_programs/vision/RightFourCoralAuto.java
+++ b/src/main/java/competition/auto_programs/vision/RightFourCoralAuto.java
@@ -13,6 +13,8 @@ import competition.subsystems.pose.vision.Paths;
 import javax.inject.Inject;
 import javax.inject.Provider;
 
+import static edu.wpi.first.units.Units.Seconds;
+
 import edu.wpi.first.wpilibj2.command.WaitCommand;
 import xbot.common.subsystems.autonomous.AutonomousCommandSelector;
 
@@ -25,7 +27,7 @@ public class RightFourCoralAuto extends BaseAutonomousSequentialCommandGroup {
             Provider<PathDriveToLocationForCoralStationFactory> pathDriveToLocationAndIntakeUntilCollectedProvider) {
         super(autoSelector);
 
-
+        this.addCommands(new WaitCommand(Seconds.of(1)));
 
         // Score 1
         getDriveAndScoreStatusMessageCommand(Landmarks.ReefFace.FAR_RIGHT,


### PR DESCRIPTION
# Why are we doing this?

Especially with the deadwheels on, we were seeing what looked like overruns causing erratic driving behavior at the start of auto. This PR adds back in a 1s delay to hopefully wait out the storm.

Asana task URL:

# Whats changing?

# Questions/notes for reviewers

# How this was tested
- [ ] tested on robot
- [ ] tested in simulator
- [ ] unit tests added

## Video/screenshots (from simulator or live robot)

-----

PR feedback legend

 
| Symbol | Meaning                  |
|--------|--------------------------|
| :star: :star: :star:     | must be addressed                 |
| :star: :star:     | should be addressed        |
| :star:     | something to consider, a good idea                  |
