### PR TITLE
feat: initial coral handing to intake and eject

### DIFF
--- a/src/main/java/competition/operator_interface/OperatorCommandMap.java
+++ b/src/main/java/competition/operator_interface/OperatorCommandMap.java
@@ -39,8 +39,8 @@ public class OperatorCommandMap {
 
     @Inject
     public void setUpOperatorCommands(OperatorInterface oi, EjectCoralCommand ejectCoralCommand, IntakeCoralCommand intakeCoralCommand) {
-        oi.driverGamepad.getifAvailable(XXboxController.XboxButton.A).onTrue(intakeCoralCommand);
-        oi.driverGamepad.getifAvailable(XXboxController.XboxButton.Y).onTrue(ejectCoralCommand);
+        oi.driverGamepad.getifAvailable(XXboxController.XboxButton.A).whileTrue(intakeCoralCommand);
+        oi.driverGamepad.getifAvailable(XXboxController.XboxButton.Y).whileTrue(ejectCoralCommand);
     }
 
     @Inject

--- a/src/main/java/competition/operator_interface/OperatorCommandMap.java
+++ b/src/main/java/competition/operator_interface/OperatorCommandMap.java
@@ -1,6 +1,8 @@
 package competition.operator_interface;
 
 import competition.simulation.commands.ResetSimulatedPose;
+import competition.subsystems.coral_scorer.commands.EjectCoralCommand;
+import competition.subsystems.coral_scorer.commands.IntakeCoralCommand;
 import competition.subsystems.drive.DriveSubsystem;
 import competition.subsystems.drive.commands.DebugSwerveModuleCommand;
 import competition.subsystems.drive.commands.SwerveDriveWithJoysticksCommand;
@@ -36,9 +38,9 @@ public class OperatorCommandMap {
 
 
     @Inject
-    public void setUpOperatorCommands(OperatorInterface oi) {
-        
-
+    public void setUpOperatorCommands(OperatorInterface oi, EjectCoralCommand ejectCoralCommand, IntakeCoralCommand intakeCoralCommand) {
+        oi.driverGamepad.getifAvailable(XXboxController.XboxButton.A).onTrue(intakeCoralCommand);
+        oi.driverGamepad.getifAvailable(XXboxController.XboxButton.Y).onTrue(ejectCoralCommand);
     }
 
     @Inject

--- a/src/main/java/competition/subsystems/SubsystemDefaultCommandMap.java
+++ b/src/main/java/competition/subsystems/SubsystemDefaultCommandMap.java
@@ -1,5 +1,7 @@
 package competition.subsystems;
 import competition.subsystems.coral_arm.CoralArmSubsystem;
+import competition.subsystems.coral_scorer.CoralScorerSubsystem;
+import competition.subsystems.coral_scorer.commands.IdleCoralCommand;
 import competition.subsystems.drive.DriveSubsystem;
 import competition.subsystems.drive.commands.SwerveDriveWithJoysticksCommand;
 import competition.subsystems.elevator.ElevatorSubsystem;
@@ -20,5 +22,10 @@ public class SubsystemDefaultCommandMap {
     @Inject
     public void setupDriveSubsystem(DriveSubsystem driveSubsystem, SwerveDriveWithJoysticksCommand command) {
         driveSubsystem.setDefaultCommand(command);
+    }
+
+    @Inject
+    public void setupCoralScorerSubsystem(CoralScorerSubsystem coralScorerSubsystem, IdleCoralCommand command) {
+        coralScorerSubsystem.setDefaultCommand(command);
     }
 }

--- a/src/main/java/competition/subsystems/coral_scorer/CoralScorerSubsystem.java
+++ b/src/main/java/competition/subsystems/coral_scorer/CoralScorerSubsystem.java
@@ -43,6 +43,18 @@ public class CoralScorerSubsystem extends BaseSubsystem {
         this.electricalContract = electricalContract;
     }
 
+    public void intake() {
+        motor.setPower(-1);
+    }
+
+    public void eject() {
+        motor.setPower(1);
+    }
+
+    public void idle() {
+        motor.setPower(0);
+    }
+
     public boolean hasCoral() {
         // TODO: return true if the coral sensor is true
         return false;

--- a/src/main/java/competition/subsystems/coral_scorer/CoralScorerSubsystem.java
+++ b/src/main/java/competition/subsystems/coral_scorer/CoralScorerSubsystem.java
@@ -5,6 +5,8 @@ import edu.wpi.first.wpilibj.Alert;
 import xbot.common.command.BaseSubsystem;
 import xbot.common.controls.actuators.XCANMotorController;
 import xbot.common.controls.sensors.XDigitalInput;
+import xbot.common.properties.DoubleProperty;
+import xbot.common.properties.Property;
 import xbot.common.properties.PropertyFactory;
 
 import javax.inject.Inject;
@@ -17,13 +19,19 @@ public class CoralScorerSubsystem extends BaseSubsystem {
 
     final Alert hasCoralAlert = new Alert("Confidently has coral", Alert.AlertType.kInfo);
     public final ElectricalContract electricalContract;
-    
+
+    DoubleProperty ejectMotorPower;
+    DoubleProperty intakeMotorPower;
 
     @Inject
     public CoralScorerSubsystem(XCANMotorController.XCANMotorControllerFactory xcanMotorControllerFactory,
                                 ElectricalContract electricalContract, PropertyFactory propertyFactory,
                                 XDigitalInput.XDigitalInputFactory xDigitalInputFactory) {
         propertyFactory.setPrefix(this);
+
+        ejectMotorPower = propertyFactory.createPersistentProperty("Eject Motor Speed", 1);
+        intakeMotorPower = propertyFactory.createPersistentProperty("Intake Motor Speed", -1);
+
         if (electricalContract.isCoralCollectionMotorReady()) {
             this.motor = xcanMotorControllerFactory.create(electricalContract.getCoralCollectionMotor(),
                     getPrefix(), "CoralScorer");
@@ -44,11 +52,11 @@ public class CoralScorerSubsystem extends BaseSubsystem {
     }
 
     public void intake() {
-        motor.setPower(-1);
+        motor.setPower(intakeMotorPower.get());
     }
 
     public void eject() {
-        motor.setPower(1);
+        motor.setPower(ejectMotorPower.get());
     }
 
     public void idle() {

--- a/src/main/java/competition/subsystems/coral_scorer/CoralScorerSubsystem.java
+++ b/src/main/java/competition/subsystems/coral_scorer/CoralScorerSubsystem.java
@@ -20,8 +20,8 @@ public class CoralScorerSubsystem extends BaseSubsystem {
     final Alert hasCoralAlert = new Alert("Confidently has coral", Alert.AlertType.kInfo);
     public final ElectricalContract electricalContract;
 
-    DoubleProperty ejectMotorPower;
-    DoubleProperty intakeMotorPower;
+    final DoubleProperty ejectMotorPower;
+    final DoubleProperty intakeMotorPower;
 
     @Inject
     public CoralScorerSubsystem(XCANMotorController.XCANMotorControllerFactory xcanMotorControllerFactory,

--- a/src/main/java/competition/subsystems/coral_scorer/commands/EjectCoralCommand.java
+++ b/src/main/java/competition/subsystems/coral_scorer/commands/EjectCoralCommand.java
@@ -2,13 +2,12 @@ package competition.subsystems.coral_scorer.commands;
 
 import competition.subsystems.coral_scorer.CoralScorerSubsystem;
 import xbot.common.command.BaseCommand;
+import xbot.common.properties.PropertyFactory;
 
 import javax.inject.Inject;
 
 public class EjectCoralCommand extends BaseCommand {
-    CoralScorerSubsystem coralScorer;
-
-    public boolean finished;
+    final CoralScorerSubsystem coralScorer;
 
     @Inject
     EjectCoralCommand(CoralScorerSubsystem coralScorerSubsystem) {
@@ -17,18 +16,7 @@ public class EjectCoralCommand extends BaseCommand {
     }
 
     @Override
-    public void initialize() {
-        this.finished = false;
-    }
-
-    @Override
     public void execute() {
         coralScorer.eject();
-        finished = true;
-    }
-
-    @Override
-    public boolean isFinished() {
-        return finished;
     }
 }

--- a/src/main/java/competition/subsystems/coral_scorer/commands/EjectCoralCommand.java
+++ b/src/main/java/competition/subsystems/coral_scorer/commands/EjectCoralCommand.java
@@ -1,0 +1,34 @@
+package competition.subsystems.coral_scorer.commands;
+
+import competition.subsystems.coral_scorer.CoralScorerSubsystem;
+import xbot.common.command.BaseCommand;
+
+import javax.inject.Inject;
+
+public class EjectCoralCommand extends BaseCommand {
+    CoralScorerSubsystem coralScorer;
+
+    public boolean finished;
+
+    @Inject
+    EjectCoralCommand(CoralScorerSubsystem coralScorerSubsystem) {
+        this.coralScorer = coralScorerSubsystem;
+        this.addRequirements(coralScorerSubsystem);
+    }
+
+    @Override
+    public void initialize() {
+        this.finished = false;
+    }
+
+    @Override
+    public void execute() {
+        coralScorer.eject();
+        finished = true;
+    }
+
+    @Override
+    public boolean isFinished() {
+        return finished;
+    }
+}

--- a/src/main/java/competition/subsystems/coral_scorer/commands/IdleCoralCommand.java
+++ b/src/main/java/competition/subsystems/coral_scorer/commands/IdleCoralCommand.java
@@ -6,9 +6,7 @@ import xbot.common.command.BaseCommand;
 import javax.inject.Inject;
 
 public class IdleCoralCommand extends BaseCommand {
-    CoralScorerSubsystem coralScorer;
-
-    public boolean finished;
+    final CoralScorerSubsystem coralScorer;
 
     @Inject
     IdleCoralCommand(CoralScorerSubsystem coralScorerSubsystem) {
@@ -19,16 +17,5 @@ public class IdleCoralCommand extends BaseCommand {
     @Override
     public void execute() {
         coralScorer.idle();
-        finished = true;
-    }
-
-    @Override
-    public void initialize() {
-        finished = false;
-    }
-
-    @Override
-    public boolean isFinished() {
-        return finished;
     }
 }

--- a/src/main/java/competition/subsystems/coral_scorer/commands/IdleCoralCommand.java
+++ b/src/main/java/competition/subsystems/coral_scorer/commands/IdleCoralCommand.java
@@ -1,0 +1,34 @@
+package competition.subsystems.coral_scorer.commands;
+
+import competition.subsystems.coral_scorer.CoralScorerSubsystem;
+import xbot.common.command.BaseCommand;
+
+import javax.inject.Inject;
+
+public class IdleCoralCommand extends BaseCommand {
+    CoralScorerSubsystem coralScorer;
+
+    public boolean finished;
+
+    @Inject
+    IdleCoralCommand(CoralScorerSubsystem coralScorerSubsystem) {
+        this.coralScorer = coralScorerSubsystem;
+        this.addRequirements(coralScorerSubsystem);
+    }
+
+    @Override
+    public void execute() {
+        coralScorer.idle();
+        finished = true;
+    }
+
+    @Override
+    public void initialize() {
+        finished = false;
+    }
+
+    @Override
+    public boolean isFinished() {
+        return finished;
+    }
+}

--- a/src/main/java/competition/subsystems/coral_scorer/commands/IntakeCoralCommand.java
+++ b/src/main/java/competition/subsystems/coral_scorer/commands/IntakeCoralCommand.java
@@ -1,0 +1,34 @@
+package competition.subsystems.coral_scorer.commands;
+
+import competition.subsystems.coral_scorer.CoralScorerSubsystem;
+import xbot.common.command.BaseCommand;
+
+import javax.inject.Inject;
+
+public class IntakeCoralCommand extends BaseCommand {
+    CoralScorerSubsystem coralScorer;
+
+    boolean finished;
+
+    @Inject
+    IntakeCoralCommand(CoralScorerSubsystem coralScorerSubsystem) {
+        this.coralScorer = coralScorerSubsystem;
+        this.addRequirements(coralScorerSubsystem);
+    }
+
+    @Override
+    public void execute() {
+        coralScorer.intake();
+        finished = true;
+    }
+
+    @Override
+    public void initialize() {
+        finished = false;
+    }
+
+    @Override
+    public boolean isFinished() {
+        return finished;
+    }
+}

--- a/src/main/java/competition/subsystems/coral_scorer/commands/IntakeCoralCommand.java
+++ b/src/main/java/competition/subsystems/coral_scorer/commands/IntakeCoralCommand.java
@@ -6,9 +6,7 @@ import xbot.common.command.BaseCommand;
 import javax.inject.Inject;
 
 public class IntakeCoralCommand extends BaseCommand {
-    CoralScorerSubsystem coralScorer;
-
-    boolean finished;
+    final CoralScorerSubsystem coralScorer;
 
     @Inject
     IntakeCoralCommand(CoralScorerSubsystem coralScorerSubsystem) {
@@ -19,16 +17,5 @@ public class IntakeCoralCommand extends BaseCommand {
     @Override
     public void execute() {
         coralScorer.intake();
-        finished = true;
-    }
-
-    @Override
-    public void initialize() {
-        finished = false;
-    }
-
-    @Override
-    public boolean isFinished() {
-        return finished;
     }
 }


### PR DESCRIPTION
# Why are we doing this?
To allow coral to eject and intake

Asana task URL: https://app.asana.com/1/2086102074315/project/1210816183240619/task/1210816183240621?focus=true

# Whats changing?
coral scorer subsystem is initialized correctly

# Questions/notes for reviewers

https://github.com/user-attachments/assets/c5b759a7-be27-4c56-8626-47f2d91e62ff

# How this was tested
- [❌ ] tested on robot
- [✔️] tested in simulator
- [❌ ] unit tests added

## Video/screenshots (from simulator or live robot)

-----

PR feedback legend

 
| Symbol | Meaning                  |
|--------|--------------------------|
| :star: :star: :star:     | must be addressed                 |
| :star: :star:     | should be addressed        |
| :star:     | something to consider, a good idea                  |
